### PR TITLE
[feat] 공통 Auditing 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,12 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 }
 

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.sparta.todayeats.global.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/entity/BaseEntity.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/entity/BaseEntity.java
@@ -1,0 +1,49 @@
+package com.sparta.todayeats.global.infrastructure.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    @CreatedBy
+    @Column(updatable = false, length = 36)
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column(length = 36)
+    private String updatedBy;
+
+    @Column(length = 36)
+    private String deletedBy;
+
+    public void softDelete(String userId) {
+        if (this.deletedAt == null) {
+            this.deletedAt = LocalDateTime.now();
+            this.deletedBy = userId;
+        }
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/entity/BaseEntity.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/entity/BaseEntity.java
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @MappedSuperclass
@@ -26,17 +27,15 @@ public abstract class BaseEntity {
     private LocalDateTime deletedAt;
 
     @CreatedBy
-    @Column(updatable = false, length = 36)
-    private String createdBy;
+    @Column(updatable = false)
+    private UUID createdBy;
 
     @LastModifiedBy
-    @Column(length = 36)
-    private String updatedBy;
+    private UUID updatedBy;
 
-    @Column(length = 36)
-    private String deletedBy;
+    private UUID deletedBy;
 
-    public void softDelete(String userId) {
+    public void softDelete(UUID userId) {
         if (this.deletedAt == null) {
             this.deletedAt = LocalDateTime.now();
             this.deletedBy = userId;


### PR DESCRIPTION
## 📌 관련 이슈
#3 


## ✨ 요약
프로젝트 전역에서 사용할 공통 Auditing 적용

- BaseEntity 구현
- JPA Auditing 설정 활성화
- Lombok annotationProcessor 설정 추가


## 상세 내용
### BaseEntity
공통 Audit 필드와 softDelete 메서드가 정의된 엔티티

### JPA Auditing
JpaConfig를 통한 JPA Auditing 기능 활성화


## 📸 스크린샷(선택)
- 없음


## 📚 레퍼런스 혹은 궁금한 사항들
- Gradle 빌드 환경에서 Lombok 정상 동작을 위해 annotationProcessor 설정 추가
- BaseEntity Auditing 테스트 필요

Closes #3 