### PR TITLE
[feat] 운영 지역 API 구현

### DIFF
--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 
 @Service
@@ -82,6 +83,15 @@ public class AreaService {
     }
 
 
+    // 운영 지역 상세 조회
+    public AreaResponse getArea(UUID areaId) {
+        Area area = getAreaEntity(areaId);
+        return toResponse(area);
+    }
+
+
+
+
     // 운영지역 목록 조회 및 검색 처리
     private Page<Area> findAreas(String keyword, Pageable pageable) {
         if (keyword == null || keyword.isBlank()) {
@@ -96,7 +106,6 @@ public class AreaService {
             throw new BaseException(AreaErrorCode.AREA_ALREADY_EXISTS);
         }
     }
-
 
     // Area 엔티티 → 목록 응답 DTO 변환
     private AreaResponse toResponse(Area area) {
@@ -122,6 +131,12 @@ public class AreaService {
         if (normalized.isBlank()) throw new BaseException(AreaErrorCode.INVALID_AREA_NAME);
 
         return normalized;
+    }
+
+    // 운영 지역 엔티티 조회
+    private Area getAreaEntity(UUID areaId) {
+        return areaRepository.findById(areaId)
+                .orElseThrow(() -> new BaseException(AreaErrorCode.AREA_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -10,6 +10,7 @@ import com.sparta.todayeats.category.presentation.dto.PageResponse;
 import com.sparta.todayeats.global.exception.AreaErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -44,8 +45,14 @@ public class AreaService {
                 .isActive(true)
                 .build();
 
-        // DB 저장
-        Area saved = areaRepository.save(area);
+        // DB 저장 (동시성 문제 해결)
+        Area saved;
+
+        try {
+            saved = areaRepository.save(area);
+        } catch (DataIntegrityViolationException e) {
+            throw new BaseException(AreaErrorCode.AREA_ALREADY_EXISTS);
+        }
 
         // 응답 DTO로 변환
         return AreaCreateResponse.builder()

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -1,0 +1,72 @@
+package com.sparta.todayeats.area.application.service;
+
+import com.sparta.todayeats.area.domain.entity.Area;
+import com.sparta.todayeats.area.domain.repository.AreaRepository;
+import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
+import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
+import com.sparta.todayeats.global.exception.AreaErrorCode;
+import com.sparta.todayeats.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AreaService {
+
+    private final AreaRepository areaRepository;
+
+    // 운영 지역 생성
+    @Transactional
+    public AreaCreateResponse createArea(AreaCreateRequest request) {
+
+        // 입력값 정규화
+        String name = normalizeName(request.getName());
+
+        // 중복 여부 검증 (city, district은 중복 가능)
+        validateDuplicateArea(name);
+
+        // 운영 지역 엔티티 생성
+        Area area = Area.builder()
+                .name(name)
+                .city(request.getCity())
+                .district(request.getDistrict())
+                .isActive(true)
+                .build();
+
+        // DB 저장
+        Area saved = areaRepository.save(area);
+
+        // 응답 DTO로 변환
+        return AreaCreateResponse.builder()
+                .areaId(saved.getId())
+                .name(saved.getName())
+                .city(saved.getCity())
+                .district(saved.getDistrict())
+                .isActive(saved.getIsActive())
+                .createdAt(saved.getCreatedAt())
+                .createdBy(saved.getCreatedBy())
+                .build();
+    }
+
+    // 운영 지역 이름 기준 중복 조회 (대소문자 상관없이 존재 여부 확인)
+    private void validateDuplicateArea(String name) {
+        if (areaRepository.existsByNameIgnoreCase(name)) {
+            throw new BaseException(AreaErrorCode.AREA_ALREADY_EXISTS);
+        }
+    }
+
+    // 운영지역 이름 정규화
+    private String normalizeName(String name) {
+        // null인 경우 예외 처리
+        if (name == null) throw new BaseException(AreaErrorCode.INVALID_AREA_NAME);
+        // 앞 뒤 공백 제거
+        String normalized = name.trim();
+        if (normalized.isBlank()) throw new BaseException(AreaErrorCode.INVALID_AREA_NAME);
+
+        return normalized;
+    }
+
+}

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -4,11 +4,17 @@ import com.sparta.todayeats.area.domain.entity.Area;
 import com.sparta.todayeats.area.domain.repository.AreaRepository;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
+import com.sparta.todayeats.area.presentation.dto.AreaResponse;
+import com.sparta.todayeats.category.presentation.dto.PageResponse;
 import com.sparta.todayeats.global.exception.AreaErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -51,11 +57,60 @@ public class AreaService {
                 .build();
     }
 
+
+    // 운영 지역 목록 조회 && 검색
+    public PageResponse<AreaResponse> getAreas(String keyword, Pageable pageable) {
+
+        // keyword가 없으면 전체 조회, 있으면 이름 기준 검색
+        Page<Area> result = findAreas(keyword, pageable);
+
+        // 엔티티 → DTO 변환
+        List<AreaResponse> content = result.getContent()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+
+        // 페이지 응답 DTO 생성
+        return PageResponse.<AreaResponse>builder()
+                .content(content)
+                .page(result.getNumber())
+                .size(result.getSize())
+                .totalElements(result.getTotalElements())
+                .totalPages(result.getTotalPages())
+                .sort(pageable.getSort().toString())
+                .build();
+    }
+
+
+    // 운영지역 목록 조회 및 검색 처리
+    private Page<Area> findAreas(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.isBlank()) {
+            return areaRepository.findAll(pageable);
+        }
+        return areaRepository.findByNameContainingIgnoreCase(keyword, pageable);
+    }
+
     // 운영 지역 이름 기준 중복 조회 (대소문자 상관없이 존재 여부 확인)
     private void validateDuplicateArea(String name) {
         if (areaRepository.existsByNameIgnoreCase(name)) {
             throw new BaseException(AreaErrorCode.AREA_ALREADY_EXISTS);
         }
+    }
+
+
+    // Area 엔티티 → 목록 응답 DTO 변환
+    private AreaResponse toResponse(Area area) {
+        return AreaResponse.builder()
+                .areaId(area.getId())
+                .name(area.getName())
+                .city(area.getCity())
+                .district(area.getDistrict())
+                .isActive(area.getIsActive())
+                .createdAt(area.getCreatedAt())
+                .createdBy(area.getCreatedBy())
+                .updatedAt(area.getUpdatedAt())
+                .updatedBy(area.getUpdatedBy())
+                .build();
     }
 
     // 운영지역 이름 정규화

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -108,7 +108,7 @@ public class AreaService {
         String name = normalizeName(request.getName());
 
         // 기존 이름과 다른 경우에만 중복 검증 수행
-        if (!area.getName().equals(name)) {
+        if (!area.getName().equalsIgnoreCase(name)) {
             validateDuplicateArea(name);
         }
 

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -83,6 +83,13 @@ public class AreaService {
                 .build();
     }
 
+   // 운영 지역 삭제
+    @Transactional
+    public void deleteArea(UUID areaId) {
+        Area area = getAreaEntity(areaId);
+        area.softDelete(null);
+    }
+
 
     // 운영 지역 상세 조회
     public AreaResponse getArea(UUID areaId) {

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -83,19 +83,13 @@ public class AreaService {
                 .build();
     }
 
-   // 운영 지역 삭제
-    @Transactional
-    public void deleteArea(UUID areaId) {
-        Area area = getAreaEntity(areaId);
-        area.softDelete(null);
-    }
-
 
     // 운영 지역 상세 조회
     public AreaResponse getArea(UUID areaId) {
         Area area = getAreaEntity(areaId);
         return toResponse(area);
     }
+
 
     // 운영 지역 수정
     @Transactional
@@ -104,25 +98,26 @@ public class AreaService {
         // 수정 대상 운영 지역 조회
         Area area = getAreaEntity(areaId);
 
-        // null이면 기존 값 유지
-        String name = request.getName() != null ? normalizeName(request.getName()) : area.getName();
-        String city = request.getCity() != null ? request.getCity() : area.getCity();
-        String district = request.getDistrict() != null ? request.getDistrict() : area.getDistrict();
-        Boolean isActive = request.getIsActive() != null ? request.getIsActive() : area.getIsActive();
+        String name = normalizeName(request.getName());
 
         // 기존 이름과 다른 경우에만 중복 검증 수행
         if (!area.getName().equals(name)) {
             validateDuplicateArea(name);
         }
 
-        // 운영 지역 이름 수정
-        area.update(name, city, district, isActive);
+        // 전체 교체
+        area.update(name, request.getCity(), request.getDistrict(), request.getIsActive());
 
         return toResponse(area);
     }
 
 
-
+    // 운영 지역 삭제
+    @Transactional
+    public void deleteArea(UUID areaId) {
+        Area area = getAreaEntity(areaId);
+        area.softDelete(null);
+    }
 
 
     // 운영지역 목록 조회 및 검색 처리

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -107,7 +107,7 @@ public class AreaService {
 
         String name = normalizeName(request.getName());
 
-        // 기존 이름과 다른 경우에만 중복 검증 수행
+        // 대소문자 무시, 중복 체크
         if (!area.getName().equalsIgnoreCase(name)) {
             validateDuplicateArea(name);
         }

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -5,6 +5,7 @@ import com.sparta.todayeats.area.domain.repository.AreaRepository;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
 import com.sparta.todayeats.area.presentation.dto.AreaResponse;
+import com.sparta.todayeats.area.presentation.dto.AreaUpdateRequest;
 import com.sparta.todayeats.category.presentation.dto.PageResponse;
 import com.sparta.todayeats.global.exception.AreaErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;
@@ -88,6 +89,31 @@ public class AreaService {
         Area area = getAreaEntity(areaId);
         return toResponse(area);
     }
+
+    // 운영 지역 수정
+    @Transactional
+    public AreaResponse updateArea(UUID areaId, AreaUpdateRequest request) {
+
+        // 수정 대상 운영 지역 조회
+        Area area = getAreaEntity(areaId);
+
+        // null이면 기존 값 유지
+        String name = request.getName() != null ? normalizeName(request.getName()) : area.getName();
+        String city = request.getCity() != null ? request.getCity() : area.getCity();
+        String district = request.getDistrict() != null ? request.getDistrict() : area.getDistrict();
+        Boolean isActive = request.getIsActive() != null ? request.getIsActive() : area.getIsActive();
+
+        // 기존 이름과 다른 경우에만 중복 검증 수행
+        if (!area.getName().equals(name)) {
+            validateDuplicateArea(name);
+        }
+
+        // 운영 지역 이름 수정
+        area.update(name, city, district, isActive);
+
+        return toResponse(area);
+    }
+
 
 
 

--- a/src/main/java/com/sparta/todayeats/area/domain/entity/Area.java
+++ b/src/main/java/com/sparta/todayeats/area/domain/entity/Area.java
@@ -38,6 +38,9 @@ public class Area extends BaseEntity {
         this.name = name;
         this.city = city;
         this.district = district;
-        this.isActive = isActive;
+
+        if (isActive != null) {
+            this.isActive = isActive;
+        }
     }
 }

--- a/src/main/java/com/sparta/todayeats/area/domain/entity/Area.java
+++ b/src/main/java/com/sparta/todayeats/area/domain/entity/Area.java
@@ -1,0 +1,43 @@
+package com.sparta.todayeats.area.domain.entity;
+
+import com.sparta.todayeats.global.infrastructure.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_area")
+@Getter
+@Builder
+@AllArgsConstructor
+@Where(clause = "deleted_at is null")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Area extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "area_id")
+    private UUID id;
+
+    @Column(nullable = false, length = 100, unique = true)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String city;
+
+    @Column(nullable = false, length = 50)
+    private String district;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+
+    public void update(String name, String city, String district, Boolean isActive) {
+        this.name = name;
+        this.city = city;
+        this.district = district;
+        this.isActive = isActive;
+    }
+}

--- a/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
+++ b/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
@@ -3,10 +3,11 @@ package com.sparta.todayeats.area.domain.repository;
 import com.sparta.todayeats.area.domain.entity.Area;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
 
 public interface AreaRepository extends JpaRepository<Area, UUID> {
     boolean existsByNameIgnoreCase(String name);
-   // Page<Area> findByNameContainingIgnoreCase(String name, Pageable pageable);
+    Page<Area> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
+++ b/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.todayeats.area.domain.repository;
+
+import com.sparta.todayeats.area.domain.entity.Area;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AreaRepository extends JpaRepository<Area, UUID> {
+    boolean existsByNameIgnoreCase(String name);
+   // Page<Area> findByNameContainingIgnoreCase(String name, Pageable pageable);
+}

--- a/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
+++ b/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 
 public interface AreaRepository extends JpaRepository<Area, UUID> {
+    // 운영지역 이름 중복 여부 확인 (대소문자 무시)
     boolean existsByNameIgnoreCase(String name);
+
+    // 운영지역 이름 기준 부분 일치(대소문자 무시) 검색 + 페이징 조회
     Page<Area> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -76,8 +76,7 @@ public class AreaController {
 
         areaService.deleteArea(areaId);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(ApiResponse.deleted(null));
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -17,7 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/areas")
@@ -46,6 +46,16 @@ public class AreaController {
             Pageable pageable) {
 
         PageResponse<AreaResponse> response = areaService.getAreas(keyword, pageable);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // TODO: Auditing
+    // 운영 지역 상세 조회
+    @GetMapping("/{areaId}")
+    public ResponseEntity<ApiResponse<AreaResponse>> getArea(@PathVariable UUID areaId) {
+
+        AreaResponse response = areaService.getArea(areaId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -61,8 +61,8 @@ public class AreaController {
 
     // TODO: 권한 처리(MANAGER, MASTER), Auditing
     // 운영 지역 수정
-    @PatchMapping("/{areaId}")
-    public ResponseEntity<ApiResponse<AreaResponse>> updateArea(@PathVariable UUID areaId, @RequestBody AreaUpdateRequest request) {
+    @PutMapping("/{areaId}")
+    public ResponseEntity<ApiResponse<AreaResponse>> updateArea(@PathVariable UUID areaId, @Valid @RequestBody AreaUpdateRequest request) {
 
         AreaResponse response = areaService.updateArea(areaId, request);
 

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -1,14 +1,23 @@
 package com.sparta.todayeats.area.presentation.controller;
 
 import com.sparta.todayeats.area.application.service.AreaService;
+import com.sparta.todayeats.area.domain.entity.Area;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
+import com.sparta.todayeats.area.presentation.dto.AreaResponse;
+import com.sparta.todayeats.category.presentation.dto.PageResponse;
 import com.sparta.todayeats.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/areas")
@@ -27,5 +36,20 @@ public class AreaController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.created(response));
     }
+
+    // TODO: Auditing
+    // 운영 지역 목록 조회 + 검색
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<AreaResponse>>> getAreas(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable) {
+
+        PageResponse<AreaResponse> response = areaService.getAreas(keyword, pageable);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+
 
 }

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -1,0 +1,31 @@
+package com.sparta.todayeats.area.presentation.controller;
+
+import com.sparta.todayeats.area.application.service.AreaService;
+import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
+import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
+import com.sparta.todayeats.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/areas")
+@RequiredArgsConstructor
+public class AreaController {
+
+    private final AreaService areaService;
+
+    // TODO: 권한 처리(MANAGER, MASTER), Auditing
+    // 운영 지역 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<AreaCreateResponse>> createArea(@Valid @RequestBody AreaCreateRequest request) {
+        AreaCreateResponse response = areaService.createArea(request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(response));
+    }
+
+}

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -5,6 +5,7 @@ import com.sparta.todayeats.area.domain.entity.Area;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
 import com.sparta.todayeats.area.presentation.dto.AreaResponse;
+import com.sparta.todayeats.area.presentation.dto.AreaUpdateRequest;
 import com.sparta.todayeats.category.presentation.dto.PageResponse;
 import com.sparta.todayeats.global.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -56,6 +57,16 @@ public class AreaController {
     public ResponseEntity<ApiResponse<AreaResponse>> getArea(@PathVariable UUID areaId) {
 
         AreaResponse response = areaService.getArea(areaId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // TODO: 권한 처리(MANAGER, MASTER), Auditing
+    // 운영 지역 수정
+    @PatchMapping("/{areaId}")
+    public ResponseEntity<ApiResponse<AreaResponse>> updateArea(@PathVariable UUID areaId, @RequestBody AreaUpdateRequest request) {
+
+        AreaResponse response = areaService.updateArea(areaId, request);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -1,7 +1,6 @@
 package com.sparta.todayeats.area.presentation.controller;
 
 import com.sparta.todayeats.area.application.service.AreaService;
-import com.sparta.todayeats.area.domain.entity.Area;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
 import com.sparta.todayeats.area.presentation.dto.AreaResponse;
@@ -10,7 +9,6 @@ import com.sparta.todayeats.category.presentation.dto.PageResponse;
 import com.sparta.todayeats.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -69,6 +67,17 @@ public class AreaController {
         AreaResponse response = areaService.updateArea(areaId, request);
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // TODO: 권한 처리(MASTER), Auditing (+ softDelete)
+    // 운영 지역 삭제
+    @DeleteMapping("/{areaId}")
+    public ResponseEntity<ApiResponse<Void>> deleteArea(@PathVariable UUID areaId) {
+
+        areaService.deleteArea(areaId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.deleted(null));
     }
 
 

--- a/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaCreateRequest.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaCreateRequest.java
@@ -1,0 +1,22 @@
+package com.sparta.todayeats.area.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 운영 지역 생성 요청 DTO
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AreaCreateRequest {
+
+    @NotBlank(message = "지역명은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "시/도는 필수입니다.")
+    private String city;
+
+    @NotBlank(message = "구/군은 필수입니다.")
+    private String district;
+}

--- a/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaCreateResponse.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaCreateResponse.java
@@ -1,0 +1,20 @@
+package com.sparta.todayeats.area.presentation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 운영 지역 생성 응답 DTO
+@Getter
+@Builder
+public class AreaCreateResponse {
+    private UUID areaId;
+    private String name;
+    private String city;
+    private String district;
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private UUID createdBy;
+}

--- a/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaResponse.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.todayeats.area.presentation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 운영 지역 응답 DTO
+@Getter
+@Builder
+public class AreaResponse {
+    private UUID areaId;
+    private String name;
+    private String city;
+    private String district;
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private UUID createdBy;
+    private LocalDateTime updatedAt;
+    private UUID updatedBy;
+}

--- a/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaUpdateRequest.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.sparta.todayeats.area.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 카테고리 수정 요청 DTO
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AreaUpdateRequest {
+
+    private String name;
+
+    private String city;
+
+    private String district;
+
+    private Boolean isActive;
+}

--- a/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaUpdateRequest.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/dto/AreaUpdateRequest.java
@@ -1,21 +1,26 @@
 package com.sparta.todayeats.area.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-// 카테고리 수정 요청 DTO
+// 운영 지역 수정 요청 DTO
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class AreaUpdateRequest {
 
+    @NotBlank(message = "지역 이름은 필수입니다")
     private String name;
 
+    @NotBlank(message = "시/도는 필수입니다")
     private String city;
 
+    @NotBlank(message = "구/군은 필수입니다")
     private String district;
 
+    @NotNull(message = "활성화 여부는 필수입니다")
     private Boolean isActive;
 }

--- a/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
+++ b/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
@@ -6,6 +6,7 @@ import com.sparta.todayeats.category.presentation.dto.*;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.exception.CategoryErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -36,8 +37,14 @@ public class CategoryService {
                 .name(name)
                 .build();
 
-        // DB 저장
-        Category saved = categoryRepository.save(category);
+        // DB 저장 (동시성 문제 해결)
+        Category saved;
+
+        try {
+            saved = categoryRepository.save(category);
+        } catch (DataIntegrityViolationException e) {
+            throw new BaseException(CategoryErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
 
         // 응답 DTO로 변환
         return CategoryCreateResponse.builder()

--- a/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
+++ b/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
@@ -129,7 +129,7 @@ public class CategoryService {
 
     // 카테고리 이름 기준 중복 조회 (존재 여부 확인)
     private void validateDuplicateCategory(String name) {
-        if (categoryRepository.existsByName(name)) {
+        if (categoryRepository.existsByNameIgnoreCase(name)) {
             throw new BaseException(CategoryErrorCode.CATEGORY_ALREADY_EXISTS);
         }
     }
@@ -139,8 +139,8 @@ public class CategoryService {
         // null인 경우 예외 처리
         if (name == null) throw new BaseException(CategoryErrorCode.INVALID_CATEGORY_NAME);
 
-        // 앞뒤 공백 제거, 영문은 소문자로 통일
-        String normalized = name.trim().toLowerCase();
+        // 앞뒤 공백 제거
+        String normalized = name.trim();
 
         // 공백일 경우 예외처리
         if (normalized.isBlank()) throw new BaseException(CategoryErrorCode.INVALID_CATEGORY_NAME);

--- a/src/main/java/com/sparta/todayeats/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/todayeats/category/domain/repository/CategoryRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
     // 카테고리 이름 중복 여부 확인
-    boolean existsByName(String name);
+    boolean existsByNameIgnoreCase(String name);
 
     // 카테고리 이름 기준 부분 일치(대소문자 무시) 검색 + 페이징 조회
     Page<Category> findByNameContainingIgnoreCase(String name, Pageable pageable);

--- a/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
@@ -72,6 +72,7 @@ public class CategoryController {
 
         categoryService.deleteCategory(categoryId);
 
-        return ResponseEntity.ok(ApiResponse.deleted(null));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.deleted(null));
     }
 }

--- a/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
@@ -72,7 +72,6 @@ public class CategoryController {
 
         categoryService.deleteCategory(categoryId);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(ApiResponse.deleted(null));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sparta/todayeats/global/exception/AreaErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/AreaErrorCode.java
@@ -1,0 +1,17 @@
+package com.sparta.todayeats.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AreaErrorCode implements ErrorCode {
+    AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "AREA-001", "지역을 찾을 수 없습니다."),
+    AREA_ALREADY_EXISTS(HttpStatus.CONFLICT, "AREA-002", "이미 존재하는 지역입니다."),
+    INVALID_AREA_NAME(HttpStatus.BAD_REQUEST, "AREA-003", "유효하지 않은 지역 이름입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
@@ -4,11 +4,14 @@ import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.exception.CommonErrorCode;
 import com.sparta.todayeats.global.exception.ErrorCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.validation.FieldError;
 
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -20,6 +23,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception e) {
         return buildResponse(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    // @Valid 검증 실패 시 발생하는 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+
+        return ResponseEntity.badRequest().body(Map.of(
+                "timestamp", LocalDateTime.now(),
+                "code", "VALID-001",
+                "message", message
+        ));
     }
 
     private ResponseEntity<?> buildResponse(ErrorCode errorCode) {

--- a/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
+++ b/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
@@ -17,7 +17,7 @@ public class DataInitializer implements ApplicationRunner {
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
-        if (areaRepository.existsByName("광화문")) return; // 이미 있으면 스킵
+        if (areaRepository.existsByNameIgnoreCase("광화문")) return; // 이미 있으면 스킵
 
         areaRepository.save(Area.builder()
                 .name("광화문")

--- a/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
+++ b/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
@@ -1,0 +1,29 @@
+package com.sparta.todayeats.global.init;
+
+import com.sparta.todayeats.area.domain.entity.Area;
+import com.sparta.todayeats.area.domain.repository.AreaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements ApplicationRunner {
+
+    private final AreaRepository areaRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (areaRepository.existsByName("광화문")) return; // 이미 있으면 스킵
+
+        areaRepository.save(Area.builder()
+                .name("광화문")
+                .city("서울특별시")
+                .district("종로구")
+                .isActive(true)
+                .build());
+    }
+}

--- a/src/test/java/com/sparta/todayeats/area/application/service/AreaServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/area/application/service/AreaServiceTest.java
@@ -1,0 +1,369 @@
+package com.sparta.todayeats.area.application.service;
+
+import com.sparta.todayeats.area.domain.entity.Area;
+import com.sparta.todayeats.area.domain.repository.AreaRepository;
+import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
+import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
+import com.sparta.todayeats.area.presentation.dto.AreaResponse;
+import com.sparta.todayeats.area.presentation.dto.AreaUpdateRequest;
+import com.sparta.todayeats.category.presentation.dto.PageResponse;
+import com.sparta.todayeats.global.exception.BaseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AreaServiceTest {
+
+    @InjectMocks
+    private AreaService areaService;
+
+    @Mock
+    private AreaRepository areaRepository;
+
+
+    // 운영 지역 생성
+    @Nested
+    @DisplayName("운영 지역 생성")
+    class CreateArea {
+
+        @Test
+        void 운영지역_생성_성공() {
+            // given
+            AreaCreateRequest request = new AreaCreateRequest("이태원", "서울특별시", "용산구");
+
+            given(areaRepository.existsByNameIgnoreCase("이태원"))
+                    .willReturn(false);
+
+            given(areaRepository.save(any(Area.class)))
+                    .willAnswer(invocation -> {
+                        Area a = invocation.getArgument(0);
+                        return Area.builder()
+                                .id(UUID.randomUUID())
+                                .name(a.getName())
+                                .city(a.getCity())
+                                .district(a.getDistrict())
+                                .isActive(true)
+                                .build();
+                    });
+
+            // when
+            AreaCreateResponse result = areaService.createArea(request);
+
+            // then
+            assertThat(result.getName()).isEqualTo("이태원");
+            assertThat(result.getCity()).isEqualTo("서울특별시");
+            assertThat(result.getDistrict()).isEqualTo("용산구");
+            assertThat(result.getIsActive()).isTrue();
+        }
+
+        @Test
+        void 운영지역_이름이_중복이면_예외발생() {
+            // given
+            AreaCreateRequest request = new AreaCreateRequest("이태원", "서울특별시", "용산구");
+
+            given(areaRepository.existsByNameIgnoreCase("이태원"))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    areaService.createArea(request)
+            ).isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 운영지역_이름_앞뒤공백은_제거후_저장() {
+            // given
+            AreaCreateRequest request = new AreaCreateRequest("  이태원  ", "서울특별시", "용산구");
+
+            given(areaRepository.existsByNameIgnoreCase("이태원"))
+                    .willReturn(false);
+
+            given(areaRepository.save(any(Area.class)))
+                    .willAnswer(invocation -> {
+                        Area a = invocation.getArgument(0);
+                        return Area.builder()
+                                .id(UUID.randomUUID())
+                                .name(a.getName())
+                                .city(a.getCity())
+                                .district(a.getDistrict())
+                                .isActive(true)
+                                .build();
+                    });
+
+            // when
+            AreaCreateResponse result = areaService.createArea(request);
+
+            // then
+            assertThat(result.getName()).isEqualTo("이태원"); // trim 됐는지 확인
+        }
+    }
+
+
+    // 운영 지역 목록 조회 및 검색
+    @Nested
+    @DisplayName("운영 지역 목록 조회")
+    class GetAreas {
+
+        @Test
+        void 운영지역_전체조회_성공() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Area area = Area.builder()
+                    .id(UUID.randomUUID())
+                    .name("이태원")
+                    .city("서울특별시")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            Page<Area> pageResult = new PageImpl<>(List.of(area), pageable, 1);
+
+            given(areaRepository.findAll(pageable))
+                    .willReturn(pageResult);
+
+            // when
+            PageResponse<AreaResponse> result = areaService.getAreas(null, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getName()).isEqualTo("이태원");
+        }
+
+        @Test
+        void 운영지역_이름으로_검색조회_성공() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Area area = Area.builder()
+                    .id(UUID.randomUUID())
+                    .name("이태원")
+                    .city("서울특별시")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            Page<Area> pageResult = new PageImpl<>(List.of(area), pageable, 1);
+
+            given(areaRepository.findByNameContainingIgnoreCase("이태", pageable))
+                    .willReturn(pageResult);
+
+            // when
+            PageResponse<AreaResponse> result = areaService.getAreas("이태", pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getName()).isEqualTo("이태원");
+        }
+    }
+
+
+    // 운영 지역 단건 조회
+    @Nested
+    @DisplayName("운영 지역 단건 조회")
+    class GetArea {
+
+        @Test
+        void 운영지역_단건조회_성공() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            Area area = Area.builder()
+                    .id(id)
+                    .name("이태원")
+                    .city("서울특별시")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.of(area));
+
+            // when
+            AreaResponse result = areaService.getArea(id);
+
+            // then
+            assertThat(result.getName()).isEqualTo("이태원");
+            assertThat(result.getCity()).isEqualTo("서울특별시");
+        }
+
+        @Test
+        void 운영지역가_존재하지_않으면_예외발생() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    areaService.getArea(id)
+            ).isInstanceOf(BaseException.class);
+        }
+    }
+
+
+    // 운영 지역 수정
+    @Nested
+    @DisplayName("운영 지역 수정")
+    class UpdateArea {
+
+        @Test
+        void 운영지역_수정_성공() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            Area area = Area.builder()
+                    .id(id)
+                    .name("이태원")
+                    .city("서울특별시")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.of(area));
+
+            AreaUpdateRequest request = new AreaUpdateRequest("광화문", "서울특별시", "종로구", true);
+
+            // when
+            AreaResponse result = areaService.updateArea(id, request);
+
+            // then
+            assertThat(result.getName()).isEqualTo("광화문");
+            assertThat(result.getDistrict()).isEqualTo("종로구");
+        }
+
+        @Test
+        void 운영지역_수정시_이름이_중복이면_예외발생() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            Area area = Area.builder()
+                    .id(id)
+                    .name("이태원")
+                    .city("서울특별시")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.of(area));
+
+            given(areaRepository.existsByNameIgnoreCase("광화문"))
+                    .willReturn(true);
+
+            AreaUpdateRequest request = new AreaUpdateRequest("광화문", "서울특별시", "종로구", true);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    areaService.updateArea(id, request)
+            ).isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 운영지역_수정시_이름이_같으면_중복검증_스킵() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            Area area = Area.builder()
+                    .id(id)
+                    .name("이태원")
+                    .city("서울특별시")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.of(area));
+
+            // 이름 동일 → existsByNameIgnoreCase 호출 안 됨
+            AreaUpdateRequest request = new AreaUpdateRequest("이태원", "서울특별시", "용산구", false);
+
+            // when
+            AreaResponse result = areaService.updateArea(id, request);
+
+            // then
+            assertThat(result.getName()).isEqualTo("이태원");
+            assertThat(result.getIsActive()).isFalse(); // isActive만 변경됨
+        }
+
+        @Test
+        void 운영지역_수정시_존재하지_않으면_예외발생() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.empty());
+
+            AreaUpdateRequest request = new AreaUpdateRequest("광화문", "서울특별시", "종로구", true);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    areaService.updateArea(id, request)
+            ).isInstanceOf(BaseException.class);
+        }
+    }
+
+
+    // 운영 지역 삭제
+    @Nested
+    @DisplayName("운영 지역 삭제")
+    class DeleteArea {
+
+        @Test
+        void 운영지역_삭제_성공() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            Area area = Area.builder()
+                    .id(id)
+                    .name("이태원")
+                    .city("서울특별시")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.of(area));
+
+            // when
+            areaService.deleteArea(id);
+
+            // then
+            assertThat(area.isDeleted()).isTrue();
+        }
+
+        @Test
+        void 운영지역_삭제시_존재하지_않으면_예외발생() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            given(areaRepository.findById(id))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    areaService.deleteArea(id)
+            ).isInstanceOf(BaseException.class);
+        }
+    }
+}

--- a/src/test/java/com/sparta/todayeats/category/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/category/application/service/CategoryServiceTest.java
@@ -44,7 +44,7 @@ class CategoryServiceTest {
             // given
             CategoryCreateRequest request = new CategoryCreateRequest("한식");
 
-            given(categoryRepository.existsByName("한식"))
+            given(categoryRepository.existsByNameIgnoreCase("한식"))
                     .willReturn(false);
 
             given(categoryRepository.save(any(Category.class)))
@@ -69,7 +69,7 @@ class CategoryServiceTest {
             // given
             CategoryCreateRequest request = new CategoryCreateRequest("한식");
 
-            given(categoryRepository.existsByName("한식"))
+            given(categoryRepository.existsByNameIgnoreCase("한식"))
                     .willReturn(true);
 
             // when & then


### PR DESCRIPTION
## 📌 관련 이슈
#14 


## ✨ 요약
- Area 엔티티 구현
- 운영 지역 생성 API 구현
- 운영 지역 목록 조회 API 구현 ( 키워드로 검색기능 추가)
- 운영 지역 단건 조회 API 구현
- 운영 지역 수정 API 구현
- 운영 지역 삭제 API 구현
- 단위 테스트 작성


## 상세 내용
- 모든 API에 권한 처리 및 auditing 적용 필요 -> JWT 발급 기능 구현 이후 반영 예정
- 유효성 검증 예외처리 추가
- isActive 필드는 기본값을 true로 설정
- 기본 Area는 광화문으로 초기 세팅
- name저장시 저장은 그대로 하지만, 중복시 예외처리 (대소문자 합쳐서), 조회시 대소문자 구분없이 조회


## 📸 스크린샷(선택)
없음


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
없음 

Closes #14 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full area management: create, read, update, delete with pagination, keyword search, and case-insensitive name handling
  * Database seeding of a default area on startup

* **Bug Fixes**
  * Improved validation error responses (aggregated messages) and standardized DELETE to return 204 NO_CONTENT
  * Duplicate-name conflicts return clear error codes

* **Tests**
  * Comprehensive tests covering area operations and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->