### PR TITLE
[feat][sub] 인증 주요 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthMailService.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthMailService.java
@@ -1,0 +1,86 @@
+package com.sparta.todayeats.auth.application.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+public class AuthMailService {
+    private final JavaMailSender mailSender;
+
+    // 이메일 인증번호 전송
+    public void sendSignupCode(String email, String code) {
+        sendEmail(
+                email,
+                "[TodayEats] 회원가입 인증 코드",
+                buildSignupEmail(code)
+        );
+    }
+
+    // 비밀번호 재설정 링크 전송
+    public void sendResetPasswordLink(String email, String resetLink) {
+        sendEmail(
+                email,
+                "[TodayEats] 비밀번호 재설정 안내",
+                buildResetPasswordEmail(resetLink)
+        );
+    }
+
+    // 공통 이메일 전송
+    private void sendEmail(String to, String subject, String html) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper =
+                    new MimeMessageHelper(message, false, "UTF-8");
+
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(html, true);
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("이메일 전송 실패", e);
+        }
+    }
+
+    // 이메일 인증 템플릿
+    private String buildSignupEmail(String code) {
+        String template = loadTemplate();
+
+        return template
+                .replace("${title}", "회원가입 인증 코드")
+                .replace("${description}", "아래 인증번호를 입력하여 회원가입을 완료해주세요.")
+                .replace("${code}", code)
+                .replace("${resetLink}", "");
+    }
+
+    // 비밀번호 재설정 템플릿
+    private String buildResetPasswordEmail(String resetLink) {
+        String template = loadTemplate();
+
+        return template
+                .replace("${title}", "비밀번호 재설정 안내")
+                .replace("${description}", "아래 버튼을 클릭하여 비밀번호를 재설정하세요.")
+                .replace("${code}", "")
+                .replace("${resetLink}", resetLink);
+    }
+
+    private String loadTemplate() {
+        try (InputStream inputStream =
+                     new ClassPathResource("templates/todayeats-auth-email.html").getInputStream()
+        ) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("템플릿 로딩 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -1,0 +1,106 @@
+package com.sparta.todayeats.auth.application.service;
+
+import com.sparta.todayeats.auth.presentation.dto.request.SignupRequest;
+import com.sparta.todayeats.auth.presentation.dto.response.*;
+import com.sparta.todayeats.global.exception.AuthErrorCode;
+import com.sparta.todayeats.global.exception.BaseException;
+import com.sparta.todayeats.global.exception.UserErrorCode;
+import com.sparta.todayeats.user.domain.entity.User;
+import com.sparta.todayeats.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceV1 {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthMailService authMailService;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String SIGNUP_PREFIX = "AUTH_SIGNUP:";
+    private static final String VERIFIED_PREFIX = "AUTH_VERIFIED:";
+
+    private static final long CODE_VALID_MINUTES = 5;
+    private static final long VERIFIED_VALID_MINUTES = 10;
+
+    public SignupResponse signup(SignupRequest request) {
+        // 이메일 인증 여부 조회
+        String email = request.getEmail();
+        String verifiedKey = VERIFIED_PREFIX + email;
+        if (!redisTemplate.hasKey(verifiedKey)) {
+            throw new BaseException(AuthErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        // 비밀번호 일치 확인
+        String password = request.getPassword();
+        if (!password.equals(request.getConfirmPassword())) {
+            throw new BaseException(UserErrorCode.PASSWORD_MISMATCH);
+        }
+
+        // 사용자 생성 및 저장
+        User user = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .nickname(request.getNickname())
+                .role(request.getRole())
+                .build();
+        userRepository.save(user);
+
+        // Redis에 이메일 인증 여부 삭제
+        redisTemplate.delete(verifiedKey);
+
+        return new SignupResponse(user);
+    }
+
+    public SendCodeResponse sendSignupCode(String email) {
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(email)) {
+            throw new BaseException(UserErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 인증번호 생성
+        String code = String.valueOf(ThreadLocalRandom.current().nextInt(100000, 1000000));
+
+        // Redis에 인증번호 저장
+        redisTemplate.opsForValue().set(
+                SIGNUP_PREFIX + email,
+                code,
+                Duration.ofMinutes(CODE_VALID_MINUTES)
+        );
+
+        // 메일 전송
+        authMailService.sendSignupCode(email, code);
+
+        return new SendCodeResponse(email, LocalDateTime.now().plusMinutes(CODE_VALID_MINUTES));
+    }
+
+    public ConfirmCodeResponse confirmSignupCode(String email, String code) {
+        // 인증번호 조회
+        String signupKey = SIGNUP_PREFIX + email;
+        String savedCode = redisTemplate.opsForValue().get(signupKey);
+        if (savedCode == null || !savedCode.equals(code)) {
+            throw new BaseException(AuthErrorCode.INVALID_VERIFICATION_CODE);
+        }
+
+        // Redis에 인증번호 삭제
+        redisTemplate.delete(signupKey);
+
+        // Redis에 이메일 인증 여부 저장
+        redisTemplate.opsForValue().set(
+                VERIFIED_PREFIX + email,
+                "true",
+                Duration.ofMinutes(VERIFIED_VALID_MINUTES)
+        );
+
+        return new ConfirmCodeResponse(email);
+    }
+}

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -5,7 +5,9 @@ import com.sparta.todayeats.auth.presentation.dto.response.*;
 import com.sparta.todayeats.global.exception.AuthErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.exception.UserErrorCode;
+import com.sparta.todayeats.global.infrastructure.config.security.JwtTokenProvider;
 import com.sparta.todayeats.user.domain.entity.User;
+import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
 import com.sparta.todayeats.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Service
@@ -25,9 +28,11 @@ public class AuthServiceV1 {
     private final PasswordEncoder passwordEncoder;
     private final AuthMailService authMailService;
     private final StringRedisTemplate redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
 
     private static final String SIGNUP_PREFIX = "AUTH_SIGNUP:";
     private static final String VERIFIED_PREFIX = "AUTH_VERIFIED:";
+    private static final String RT_PREFIX = "AUTH_RT:";
 
     private static final long CODE_VALID_MINUTES = 5;
     private static final long VERIFIED_VALID_MINUTES = 10;
@@ -102,5 +107,37 @@ public class AuthServiceV1 {
         );
 
         return new ConfirmCodeResponse(email);
+    }
+
+    public LoginResponse login(String email, String password) {
+        // 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 일치 확인
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BaseException(UserErrorCode.PASSWORD_MISMATCH);
+        }
+
+        // Token 생성
+        UUID userId = user.getUserId();
+        UserRoleEnum role = user.getRole();
+        String accessToken = jwtTokenProvider.createAccessToken(userId, role);
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        // Redis에 Refresh Token 저장
+        redisTemplate.opsForValue().set(
+                RT_PREFIX + userId,
+                refreshToken,
+                jwtTokenProvider.getRefreshTokenValidityDuration()
+        );
+
+        return LoginResponse.builder()
+                .userId(userId)
+                .nickname(user.getNickname())
+                .role(role.name())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
@@ -28,4 +28,9 @@ public class AuthControllerV1 {
     public ResponseEntity<ConfirmCodeResponse> confirmSignupCode(@Valid @RequestBody ConfirmCodeRequest request) {
         return ResponseEntity.ok(authServiceV1.confirmSignupCode(request.getEmail(), request.getCode()));
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authServiceV1.login(request.getEmail(), request.getPassword()));
+    }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
@@ -1,0 +1,31 @@
+package com.sparta.todayeats.auth.presentation.controller;
+
+import com.sparta.todayeats.auth.application.service.AuthServiceV1;
+import com.sparta.todayeats.auth.presentation.dto.request.*;
+import com.sparta.todayeats.auth.presentation.dto.response.*;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthControllerV1 {
+    private final AuthServiceV1 authServiceV1;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
+        return ResponseEntity.ok(authServiceV1.signup(request));
+    }
+
+    @PostMapping("/verify-code/send")
+    public ResponseEntity<SendCodeResponse> sendSignupCode(@Valid @RequestBody SendCodeRequest request) {
+        return ResponseEntity.ok(authServiceV1.sendSignupCode(request.getEmail()));
+    }
+
+    @PostMapping("/verify-code/confirm")
+    public ResponseEntity<ConfirmCodeResponse> confirmSignupCode(@Valid @RequestBody ConfirmCodeRequest request) {
+        return ResponseEntity.ok(authServiceV1.confirmSignupCode(request.getEmail(), request.getCode()));
+    }
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ConfirmCodeRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ConfirmCodeRequest.java
@@ -1,0 +1,19 @@
+package com.sparta.todayeats.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ConfirmCodeRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "인증 번호는 필수입니다.")
+    @Pattern(regexp = "\\d{6}", message = "인증 번호는 6자리 숫자입니다.")
+    private String code;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.sparta.todayeats.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SendCodeRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SendCodeRequest.java
@@ -1,0 +1,14 @@
+package com.sparta.todayeats.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SendCodeRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
@@ -1,0 +1,31 @@
+package com.sparta.todayeats.auth.presentation.dto.request;
+
+import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignupRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+            message = "비밀번호는 8~15자이며, 대소문자, 숫자, 특수문자를 모두 포함해야 합니다."
+    )
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다.")
+    private String confirmPassword;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 20, message = "닉네임은 2~20자 사이여야 합니다.")
+    private String nickname;
+
+    @NotNull(message = "회원 유형 선택은 필수입니다.")
+    private UserRoleEnum role;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
@@ -28,4 +28,9 @@ public class SignupRequest {
 
     @NotNull(message = "회원 유형 선택은 필수입니다.")
     private UserRoleEnum role;
+
+    @AssertTrue(message = "가입 가능한 회원 유형이 아닙니다.")
+    public boolean isValidRole() {
+        return role == UserRoleEnum.CUSTOMER || role == UserRoleEnum.OWNER;
+    }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/ConfirmCodeResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/ConfirmCodeResponse.java
@@ -1,0 +1,10 @@
+package com.sparta.todayeats.auth.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ConfirmCodeResponse {
+    private String email;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.sparta.todayeats.auth.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LoginResponse {
+    private UUID userId;
+    private String nickname;
+    private String role;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SendCodeResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SendCodeResponse.java
@@ -1,0 +1,13 @@
+package com.sparta.todayeats.auth.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class SendCodeResponse {
+    private String email;
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
@@ -5,7 +5,6 @@ import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Getter
 public class SignupResponse {
@@ -13,13 +12,11 @@ public class SignupResponse {
     private final String nickname;
     private final UserRoleEnum role;
     private final LocalDateTime createdAt;
-    private final UUID createdBy;
 
     public SignupResponse(User user) {
         this.email = user.getEmail();
         this.nickname = user.getNickname();
         this.role = user.getRole();
         this.createdAt = user.getCreatedAt();
-        this.createdBy = user.getCreatedBy();
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
@@ -1,0 +1,25 @@
+package com.sparta.todayeats.auth.presentation.dto.response;
+
+import com.sparta.todayeats.user.domain.entity.User;
+import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class SignupResponse {
+    private final String email;
+    private final String nickname;
+    private final UserRoleEnum role;
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+
+    public SignupResponse(User user) {
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.role = user.getRole();
+        this.createdAt = user.getCreatedAt();
+        this.createdBy = user.getCreatedBy();
+    }
+}

--- a/src/main/java/com/sparta/todayeats/global/exception/AuthErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/AuthErrorCode.java
@@ -9,8 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-001", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH-002", "접근 권한이 없습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-003", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-004", "만료된 토큰입니다.");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-003", "토큰이 유효하지 않습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-004", "토큰이 만료되었습니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTH-005", "인증번호가 일치하지 않거나 만료되었습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH-006", "이메일 인증이 완료되지 않았습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/global/exception/UserErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/UserErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "사용자를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USER-002", "이미 사용 중인 이메일입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER-003", "비밀번호가 올바르지 않습니다.");
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "USER-003", "비밀번호가 일치하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByEmail(String email);
-    Optional<Object> findByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByEmail(String email);
+    Optional<Object> findByEmail(String email);
 }

--- a/src/main/resources/templates/todayeats-auth-email.html
+++ b/src/main/resources/templates/todayeats-auth-email.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>오늘한끼 인증 안내</title>
+
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f6f7f9;
+            margin: 0;
+            padding: 0;
+        }
+
+        .container {
+            max-width: 520px;
+            margin: 40px auto;
+            padding: 24px;
+            background-color: #ffffff;
+            border-radius: 12px;
+            border: 1px solid #e5e5e5;
+            text-align: center;
+        }
+
+        .logo {
+            font-size: 22px;
+            font-weight: bold;
+            color: #ff6b35;
+            margin-bottom: 20px;
+        }
+
+        h2 {
+            font-size: 18px;
+            color: #333;
+        }
+
+        p {
+            font-size: 14px;
+            color: #666;
+            line-height: 1.5;
+        }
+
+        .code-box {
+            font-size: 26px;
+            font-weight: bold;
+            color: #ff6b35;
+            background-color: #fff3ee;
+            padding: 14px;
+            border-radius: 8px;
+            display: inline-block;
+            margin: 20px 0;
+            letter-spacing: 3px;
+        }
+
+        .button {
+            display: inline-block;
+            padding: 12px 18px;
+            margin-top: 15px;
+            background-color: #ff6b35;
+            color: #ffffff;
+            text-decoration: none;
+            border-radius: 8px;
+            font-weight: bold;
+        }
+
+        .footer {
+            margin-top: 24px;
+            font-size: 12px;
+            color: #aaa;
+        }
+    </style>
+
+</head>
+
+<body>
+<div class="container">
+
+    <div class="logo">오늘한끼</div>
+
+    <h2>${title}</h2>
+
+    <p>${description}</p>
+
+    <!-- 인증 코드 -->
+    <div class="code-box">${code}</div>
+
+    <!-- 비밀번호 재설정 링크 -->
+    <a href="${resetLink}" class="button">비밀번호 재설정하기</a>
+
+    <p class="footer">
+        이 인증 정보는 <strong>5분</strong> 동안 유효합니다.<br/>
+        본인이 요청하지 않은 경우 이 메일을 무시해주세요.
+    </p>
+
+    <p class="footer">
+        문의: support@todayeats.com
+    </p>
+
+</div>
+</body>
+</html>

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,18 @@ spring:
       ddl-auto: create-drop
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: test
+    password: test
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 jwt:
   secret-key: dGVzdC1zZWNyZXQta2V5LWZvci1jaS1tdXN0LWJlLWxvbmctZW5vdWdo
   access-expiration: 1800000 # 30분 (30 * 60 * 1000)


### PR DESCRIPTION
## 📌 관련 이슈
#21 


## ✨ 요약
회원가입 및 로그인 API 구현


## 상세 내용
### 회원가입 API
- 이메일 인증이 완료된 사용자만 회원가입
- 인증번호 및 인증 여부를 Redis에 저장

### 로그인 API
- 이메일/비밀번호 기반 로그인
- 성공 시 Access Token과 Refresh Token 발급
- Refresh Token을 Redis에 저장


## 📸 스크린샷(선택)
- 없음


## 📚 레퍼런스 혹은 궁금한 사항들
- 없음

Closes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email-based signup with time-limited verification codes (5 minutes)
  * Password reset via emailed recovery links
  * Authentication with access and refresh tokens
  * New API endpoints for signup, login, sending/confirming verification codes

* **Bug Fixes / UX**
  * Clarified authentication and password error messages for users
  * Added explicit errors for invalid/expired verification codes and unverified emails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->