### PR TITLE
[feat][sub] 인증 보조 API 구현

### DIFF
--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -140,4 +140,36 @@ public class AuthServiceV1 {
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    public TokenResponse reissue(String refreshToken) {
+        // 토큰 유효성 검사
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new BaseException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        // userId 추출
+        UUID userId = jwtTokenProvider.getUserId(refreshToken);
+
+        // Refresh Token 조회
+        String rtKey = RT_PREFIX + userId;
+        String savedRefreshToken = redisTemplate.opsForValue().get(rtKey);
+        if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+            throw new BaseException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        // Access Token & Refresh Token 재발급
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId, user.getRole());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        // Redis에 Refresh Token 저장
+        redisTemplate.opsForValue().set(
+                rtKey,
+                newRefreshToken,
+                jwtTokenProvider.getRefreshTokenValidityDuration()
+        );
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
 }

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -11,6 +11,7 @@ import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
 import com.sparta.todayeats.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -171,5 +172,10 @@ public class AuthServiceV1 {
         );
 
         return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    public void logout(Authentication authentication) {
+        // Redis에서 Refresh Token 삭제
+        redisTemplate.delete(RT_PREFIX + authentication.getPrincipal());
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -181,23 +181,21 @@ public class AuthServiceV1 {
     }
 
     public SendCodeResponse sendPasswordResetLink(String email) {
-        // 이메일 존재 여부 확인
-        if (!userRepository.existsByEmail(email)) {
-            throw new BaseException(UserErrorCode.USER_NOT_FOUND);
+        // 이메일 존재 시에만 수행
+        if (userRepository.existsByEmail(email)) {
+            // 인증번호 생성
+            String code = UUID.randomUUID().toString();
+
+            // Redis에 인증번호 저장
+            redisTemplate.opsForValue().set(
+                    RESET_PASSWORD_PREFIX + code,
+                    email,
+                    Duration.ofMinutes(CODE_VALID_MINUTES)
+            );
+
+            // 메일 전송
+            authMailService.sendResetPasswordLink(email, code);
         }
-
-        // 인증번호 생성
-        String code = UUID.randomUUID().toString();
-
-        // Redis에 인증번호 저장
-        redisTemplate.opsForValue().set(
-                RESET_PASSWORD_PREFIX + code,
-                email,
-                Duration.ofMinutes(CODE_VALID_MINUTES)
-        );
-
-        // 메일 전송
-        authMailService.sendResetPasswordLink(email, code);
 
         return new SendCodeResponse(email, LocalDateTime.now().plusMinutes(CODE_VALID_MINUTES));
     }

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -34,6 +34,7 @@ public class AuthServiceV1 {
     private static final String SIGNUP_PREFIX = "AUTH_SIGNUP:";
     private static final String VERIFIED_PREFIX = "AUTH_VERIFIED:";
     private static final String RT_PREFIX = "AUTH_RT:";
+    private static final String RESET_PASSWORD_PREFIX = "AUTH_RESET_PASSWORD:";
 
     private static final long CODE_VALID_MINUTES = 5;
     private static final long VERIFIED_VALID_MINUTES = 10;
@@ -177,5 +178,62 @@ public class AuthServiceV1 {
     public void logout(Authentication authentication) {
         // Redis에서 Refresh Token 삭제
         redisTemplate.delete(RT_PREFIX + authentication.getPrincipal());
+    }
+
+    public SendCodeResponse sendPasswordResetLink(String email) {
+        // 이메일 존재 여부 확인
+        if (!userRepository.existsByEmail(email)) {
+            throw new BaseException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        // 인증번호 생성
+        String code = UUID.randomUUID().toString();
+
+        // Redis에 인증번호 저장
+        redisTemplate.opsForValue().set(
+                RESET_PASSWORD_PREFIX + code,
+                email,
+                Duration.ofMinutes(CODE_VALID_MINUTES)
+        );
+
+        // 메일 전송
+        authMailService.sendResetPasswordLink(email, code);
+
+        return new SendCodeResponse(email, LocalDateTime.now().plusMinutes(CODE_VALID_MINUTES));
+    }
+
+    @Transactional(readOnly = true)
+    public ConfirmCodeResponse confirmPasswordResetLink(String code) {
+        // 인증번호 조회
+        return new ConfirmCodeResponse(getEmailByResetCode(code));
+    }
+
+    public PasswordResetResponse passwordReset(String code, String newPassword, String confirmPassword) {
+        // 인증번호 조회
+        String email = getEmailByResetCode(code);
+
+        // 비밀번호 일치 확인
+        if (!newPassword.equals(confirmPassword)) {
+            throw new BaseException(UserErrorCode.PASSWORD_MISMATCH);
+        }
+
+        // 사용자 조회 및 비밀번호 변경
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+        user.updatePassword(passwordEncoder.encode(newPassword));
+
+        // Redis에 인증번호 삭제
+        redisTemplate.delete(RESET_PASSWORD_PREFIX + code);
+
+        return new PasswordResetResponse(user.getEmail(), user.getUpdatedAt());
+    }
+
+    private String getEmailByResetCode(String code) {
+        String email = redisTemplate.opsForValue().get(RESET_PASSWORD_PREFIX + code);
+        if (email == null) {
+            throw new BaseException(AuthErrorCode.INVALID_VERIFICATION_CODE);
+        }
+
+        return email;
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
@@ -6,6 +6,7 @@ import com.sparta.todayeats.auth.presentation.dto.response.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -37,5 +38,11 @@ public class AuthControllerV1 {
     @PostMapping("/reissue")
     public ResponseEntity<TokenResponse> reissue(@Valid @RequestBody RefreshTokenRequest request) {
         return ResponseEntity.ok(authServiceV1.reissue(request.getRefreshToken()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(Authentication authentication) {
+        authServiceV1.logout(authentication);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
@@ -33,4 +33,9 @@ public class AuthControllerV1 {
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authServiceV1.login(request.getEmail(), request.getPassword()));
     }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(@Valid @RequestBody RefreshTokenRequest request) {
+        return ResponseEntity.ok(authServiceV1.reissue(request.getRefreshToken()));
+    }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
@@ -45,4 +45,21 @@ public class AuthControllerV1 {
         authServiceV1.logout(authentication);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/password-reset/send")
+    public ResponseEntity<SendCodeResponse> sendPasswordResetLink(@Valid @RequestBody SendCodeRequest request) {
+        return ResponseEntity.ok(authServiceV1.sendPasswordResetLink(request.getEmail()));
+    }
+
+    @GetMapping("/password-reset")
+    public ResponseEntity<ConfirmCodeResponse> confirmPasswordResetLink(@RequestParam String code) {
+        return ResponseEntity.ok(authServiceV1.confirmPasswordResetLink(code));
+    }
+
+    @PatchMapping("/password-reset")
+    public ResponseEntity<PasswordResetResponse> passwordReset(
+            @RequestParam String code, @Valid @RequestBody PasswordResetRequest request
+    ) {
+        return ResponseEntity.ok(authServiceV1.passwordReset(code, request.getNewPassword(), request.getConfirmPassword()));
+    }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/PasswordResetRequest.java
@@ -1,0 +1,20 @@
+package com.sparta.todayeats.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PasswordResetRequest {
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+            message = "비밀번호는 8~15자이며, 대소문자, 숫자, 특수문자를 모두 포함해야 합니다."
+    )
+    private String newPassword;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다.")
+    private String confirmPassword;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package com.sparta.todayeats.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenRequest {
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/PasswordResetResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/PasswordResetResponse.java
@@ -1,0 +1,13 @@
+package com.sparta.todayeats.auth.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PasswordResetResponse {
+    private String email;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/TokenResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.sparta.todayeats.auth.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}


### PR DESCRIPTION
## 📌 관련 이슈
#22


## ✨ 요약
토큰 재발급, 로그아웃, 비밀번호 재설정 API 구현


## 상세 내용
### 토큰 재발급 API
- Refresh Token 유효성 검증 후 Redis 조회
- 성공 시 Access Token과 Refresh Token 재발급
- Redis에 새로운 Refresh Token 저장

### 로그아웃 API
- Redis에 저장된 Refresh Token 삭제

### 비밀번호 재설정 API
- 이메일 인증 기반 비밀번호 재설정 링크 전송
- Redis에 인증번호 저장
- 인증번호 인증이 완료된 사용자만 비밀번호 변경
- Redis에 저장된 인증번호 삭제


## 📸 스크린샷(선택)
- 없음


## 📚 레퍼런스 혹은 궁금한 사항들
- 없음

Closes #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token refresh capability to extend user sessions without re-authentication.
  * Added logout endpoint to terminate user sessions.
  * Added password reset flow: request a reset link via email, confirm a reset code, and update passwords with confirmation.
  * Password reset enforces a strong password policy and returns reset expiry information when sending links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->