### PR TITLE
[test] AuthServiceV1 단위 테스트 구현

### DIFF
--- a/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
+++ b/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
@@ -1,0 +1,456 @@
+package com.sparta.todayeats.auth.application.service;
+
+import com.sparta.todayeats.auth.presentation.dto.request.SignupRequest;
+import com.sparta.todayeats.auth.presentation.dto.response.*;
+import com.sparta.todayeats.global.exception.AuthErrorCode;
+import com.sparta.todayeats.global.exception.BaseException;
+import com.sparta.todayeats.global.exception.UserErrorCode;
+import com.sparta.todayeats.global.infrastructure.config.security.JwtTokenProvider;
+import com.sparta.todayeats.user.domain.entity.User;
+import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
+import com.sparta.todayeats.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceV1Test {
+    @InjectMocks
+    private AuthServiceV1 authServiceV1;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthMailService authMailService;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private static final String SIGNUP_PREFIX = "AUTH_SIGNUP:";
+    private static final String VERIFIED_PREFIX = "AUTH_VERIFIED:";
+    private static final String RT_PREFIX = "AUTH_RT:";
+    private static final String RESET_PASSWORD_PREFIX = "AUTH_RESET_PASSWORD:";
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final String EMAIL = "test@test.com";
+    private static final String PASSWORD = "decoded";
+    private static final String ENCODED_PASSWORD = "encoded";
+    private static final String NICKNAME = "nick";
+    private static final String CODE = "123456";
+
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final String REFRESH_TOKEN = "refresh-token";
+
+    private static final String RT_KEY = RT_PREFIX + USER_ID;
+
+    @Nested
+    @DisplayName("signup()")
+    class Signup {
+        @Test
+        void 회원가입_성공() {
+            // given
+            SignupRequest request = signupRequest(PASSWORD);
+
+            given(redisTemplate.hasKey(VERIFIED_PREFIX + EMAIL)).willReturn(true);
+            given(userRepository.save(any())).willAnswer(i -> i.getArgument(0));
+            given(passwordEncoder.encode(any())).willReturn(ENCODED_PASSWORD);
+
+            // when
+            SignupResponse response = authServiceV1.signup(request);
+
+            // then
+            assertThat(response.getEmail()).isEqualTo(EMAIL);
+            verify(userRepository).save(any());
+        }
+
+        @Test
+        void 회원가입_실패_이메일_미인증() {
+            // given
+            SignupRequest request = signupRequest(PASSWORD);
+
+            given(redisTemplate.hasKey(VERIFIED_PREFIX + EMAIL)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.signup(request))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(AuthErrorCode.EMAIL_NOT_VERIFIED.getMessage());
+        }
+
+        @Test
+        void 회원가입_실패_비밀번호_불일치() {
+            // given
+            SignupRequest request = signupRequest("12345");
+
+            given(redisTemplate.hasKey(VERIFIED_PREFIX + EMAIL)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.signup(request))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.PASSWORD_MISMATCH.getMessage());
+        }
+
+        private SignupRequest signupRequest(String confirmPassword) {
+            return SignupRequest.builder()
+                    .email(EMAIL)
+                    .password(PASSWORD)
+                    .confirmPassword(confirmPassword)
+                    .nickname(NICKNAME)
+                    .role(UserRoleEnum.CUSTOMER)
+                    .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("sendSignupCode()")
+    class SendSignupCode {
+        @Test
+        void 인증번호_전송_성공() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(false);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+            // when
+            SendCodeResponse response = authServiceV1.sendSignupCode(EMAIL);
+
+            // then
+            assertThat(response.getEmail()).isEqualTo(EMAIL);
+            verify(redisTemplate.opsForValue()).set(
+                    startsWith(SIGNUP_PREFIX),
+                    anyString(),
+                    any()
+            );
+            verify(authMailService).sendSignupCode(eq(EMAIL), anyString());
+        }
+
+        @Test
+        void 인증번호_전송_실패() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.sendSignupCode(EMAIL))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.DUPLICATE_EMAIL.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmSignupCode()")
+    class ConfirmSignupCode {
+        @Test
+        void 인증번호_검증_성공() {
+            // given
+            String signupKey = SIGNUP_PREFIX + EMAIL;
+            String verifiedKey = VERIFIED_PREFIX + EMAIL;
+
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(signupKey)).willReturn(CODE);
+
+            // when
+            ConfirmCodeResponse response = authServiceV1.confirmSignupCode(EMAIL, CODE);
+
+            // then
+            assertThat(response.getEmail()).isEqualTo(EMAIL);
+            verify(redisTemplate).delete(signupKey);
+            verify(valueOperations).set(
+                    eq(verifiedKey),
+                    eq("true"),
+                    any()
+            );
+        }
+
+        @Test
+        void 인증번호_검증_실패_인증번호_없음() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.sendSignupCode(EMAIL))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.DUPLICATE_EMAIL.getMessage());
+        }
+
+        @Test
+        void 인증번호_검증_실패_인증번호_불일치() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.sendSignupCode(EMAIL))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.DUPLICATE_EMAIL.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("login()")
+    class Login {
+        @Test
+        void 로그인_성공() {
+            // given
+            User user = User.builder()
+                    .email(EMAIL)
+                    .password(ENCODED_PASSWORD)
+                    .nickname(NICKNAME)
+                    .role(UserRoleEnum.CUSTOMER)
+                    .build();
+
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).willReturn(true);
+            given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(any())).willReturn(REFRESH_TOKEN);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtTokenProvider.getRefreshTokenValidityDuration()).willReturn(Duration.ofDays(7));
+
+            // when
+            LoginResponse response = authServiceV1.login(EMAIL, PASSWORD);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getAccessToken()).isEqualTo(ACCESS_TOKEN);
+            verify(redisTemplate.opsForValue()).set(
+                    startsWith(RT_PREFIX),
+                    eq(REFRESH_TOKEN),
+                    any()
+            );
+        }
+
+        @Test
+        void 로그인_실패_사용자_없음() {
+            // given
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.login(EMAIL, PASSWORD))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 로그인_실패_비밀번호_불일치() {
+            // given
+            User user = User.builder()
+                    .email(EMAIL)
+                    .password(ENCODED_PASSWORD)
+                    .build();
+
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.login(EMAIL, PASSWORD))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.PASSWORD_MISMATCH.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("reissue()")
+    class Reissue {
+        @Test
+        void 토큰_재발급_성공() {
+            // given
+            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(RT_KEY)).willReturn(REFRESH_TOKEN);
+
+            User user = User.builder()
+                    .email(EMAIL)
+                    .role(UserRoleEnum.CUSTOMER)
+                    .build();
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(any())).willReturn(REFRESH_TOKEN);
+            given(jwtTokenProvider.getRefreshTokenValidityDuration()).willReturn(Duration.ofDays(7));
+
+            // when
+            TokenResponse response = authServiceV1.reissue(REFRESH_TOKEN);
+
+            // then
+            assertThat(response.getAccessToken()).isEqualTo(ACCESS_TOKEN);
+            assertThat(response.getRefreshToken()).isEqualTo(REFRESH_TOKEN);
+            verify(valueOperations).set(
+                    eq(RT_KEY),
+                    eq(REFRESH_TOKEN),
+                    any()
+            );
+        }
+
+        @Test
+        void 토큰_재발급_실패_토큰_미유효() {
+            // given
+            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.reissue(REFRESH_TOKEN))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
+        }
+
+        @Test
+        void 토큰_재발급_실패_토큰_불일치() {
+            // given
+            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(RT_KEY)).willReturn("other-token");
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.reissue(REFRESH_TOKEN))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
+        }
+
+        @Test
+        void 토큰재발급_실패_사용자_없음() {
+            // given
+            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(RT_KEY)).willReturn(REFRESH_TOKEN);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.reissue(REFRESH_TOKEN))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("logout()")
+    void 로그아웃_성공() {
+        // given
+        Authentication authentication = mock(Authentication.class);
+        given(authentication.getPrincipal()).willReturn(USER_ID.toString());
+
+        // when
+        authServiceV1.logout(authentication);
+
+        // then
+        verify(redisTemplate).delete(RT_KEY);
+    }
+
+    @Test
+    @DisplayName("sendPasswordResetLink()")
+    void 재설정_링크_전송_성공() {
+        // given
+        given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        SendCodeResponse response = authServiceV1.sendPasswordResetLink(EMAIL);
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(EMAIL);
+        verify(valueOperations).set(
+                startsWith(RESET_PASSWORD_PREFIX),
+                eq(EMAIL),
+                any()
+        );
+        verify(authMailService).sendResetPasswordLink(eq(EMAIL), anyString());
+    }
+
+    @Nested
+    @DisplayName("passwordReset()")
+    class PasswordReset {
+        private final String NEW_PASSWORD = "decoded-new";
+
+        @Test
+        void 비밀번호_재설정_성공() {
+            // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(resetKey())).willReturn(EMAIL);
+
+            User user = User.builder()
+                    .email(EMAIL)
+                    .password("encoded-old")
+                    .build();
+
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+            given(passwordEncoder.encode(NEW_PASSWORD)).willReturn("encoded-new");
+
+            // when
+            PasswordResetResponse response = authServiceV1.passwordReset(CODE, NEW_PASSWORD, NEW_PASSWORD);
+
+            // then
+            assertThat(response.getEmail()).isEqualTo(EMAIL);
+            verify(redisTemplate).delete(resetKey());
+            verify(passwordEncoder).encode(NEW_PASSWORD);
+        }
+
+        @Test
+        void 비밀번호_재설정_실패_코드없음() {
+            // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(resetKey())).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.passwordReset(CODE, NEW_PASSWORD, NEW_PASSWORD))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(AuthErrorCode.INVALID_VERIFICATION_CODE.getMessage());
+        }
+
+        @Test
+        void 비밀번호_재설정_실패_비밀번호_불일치() {
+            // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(resetKey())).willReturn(EMAIL);
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.passwordReset(CODE, "a", "b"))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.PASSWORD_MISMATCH.getMessage());
+        }
+
+        @Test
+        void 비밀번호재설정_실패_사용자_없음() {
+            // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(resetKey())).willReturn(EMAIL);
+
+            given(userRepository.findByEmail(EMAIL))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.passwordReset(CODE, NEW_PASSWORD, NEW_PASSWORD))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+        private String resetKey() {
+            return RESET_PASSWORD_PREFIX + CODE;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#23 


## ✨ 요약
인증 API에 대한 서비스 단위 테스트 작성


## 상세 내용
### AuthServiceV1Test 
회원가입, 로그인, 토큰 재발급, 로그아웃, 비밀번호 재설정 테스트


## 📸 스크린샷(선택)
- 없음


## 📚 레퍼런스 혹은 궁금한 사항들
- 없음

Closed #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the authentication service, validating successful flows and error handling across signup, account verification, login, token refresh, and password reset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->