### PR TITLE
[refactor] 인증 API 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     // email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthMailService.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthMailService.java
@@ -3,84 +3,66 @@ package com.sparta.todayeats.auth.application.service;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Service
 @RequiredArgsConstructor
 public class AuthMailService {
     private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    @Value("${app.url.base}")
+    private String baseUrl;
+
+    @Value("${app.url.password-reset-path}")
+    private String resetPath;
 
     // 이메일 인증번호 전송
     public void sendSignupCode(String email, String code) {
+        Context context = new Context();
+        context.setVariable("title", "비밀번호 재설정 안내");
+        context.setVariable("description", "아래 버튼을 클릭하여 새로운 비밀번호를 설정하세요.");
+        context.setVariable("code", code);
+
         sendEmail(
                 email,
-                "[TodayEats] 회원가입 인증 코드",
-                buildSignupEmail(code)
+                "[TodayEats] 회원가입 인증번호",
+                templateEngine.process("todayeats-auth-email", context)
         );
     }
 
     // 비밀번호 재설정 링크 전송
-    public void sendResetPasswordLink(String email, String resetLink) {
+    public void sendPasswordResetLink(String email, String code) {
+        Context context = new Context();
+        context.setVariable("title", "비밀번호 재설정 안내");
+        context.setVariable("description", "아래 버튼을 클릭하여 새로운 비밀번호를 설정하세요.");
+        context.setVariable("resetLink", baseUrl + resetPath + "?code=" + code);
+
         sendEmail(
                 email,
                 "[TodayEats] 비밀번호 재설정 안내",
-                buildResetPasswordEmail(resetLink)
+                templateEngine.process("todayeats-auth-email", context)
         );
     }
 
     // 공통 이메일 전송
-    private void sendEmail(String to, String subject, String html) {
+    private void sendEmail(String to, String subject, String htmlContent) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper =
-                    new MimeMessageHelper(message, false, "UTF-8");
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
 
             helper.setTo(to);
             helper.setSubject(subject);
-            helper.setText(html, true);
+            helper.setText(htmlContent, true);
 
             mailSender.send(message);
         } catch (MessagingException e) {
             throw new RuntimeException("이메일 전송 실패", e);
-        }
-    }
-
-    // 이메일 인증 템플릿
-    private String buildSignupEmail(String code) {
-        String template = loadTemplate();
-
-        return template
-                .replace("${title}", "회원가입 인증 코드")
-                .replace("${description}", "아래 인증번호를 입력하여 회원가입을 완료해주세요.")
-                .replace("${code}", code)
-                .replace("${resetLink}", "");
-    }
-
-    // 비밀번호 재설정 템플릿
-    private String buildResetPasswordEmail(String resetLink) {
-        String template = loadTemplate();
-
-        return template
-                .replace("${title}", "비밀번호 재설정 안내")
-                .replace("${description}", "아래 버튼을 클릭하여 비밀번호를 재설정하세요.")
-                .replace("${code}", "")
-                .replace("${resetLink}", resetLink);
-    }
-
-    private String loadTemplate() {
-        try (InputStream inputStream =
-                     new ClassPathResource("templates/todayeats-auth-email.html").getInputStream()
-        ) {
-            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new RuntimeException("템플릿 로딩 실패", e);
         }
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthMailService.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthMailService.java
@@ -25,8 +25,8 @@ public class AuthMailService {
     // 이메일 인증번호 전송
     public void sendSignupCode(String email, String code) {
         Context context = new Context();
-        context.setVariable("title", "비밀번호 재설정 안내");
-        context.setVariable("description", "아래 버튼을 클릭하여 새로운 비밀번호를 설정하세요.");
+        context.setVariable("title", "회원가입 인증번호");
+        context.setVariable("description", "아래 인증번호를 입력하여 회원가입을 완료해주세요.");
         context.setVariable("code", code);
 
         sendEmail(

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -188,7 +188,7 @@ public class AuthServiceV1 {
         redisTemplate.delete(RT_PREFIX + userId);
     }
 
-    public SendCodeResponse sendResetPasswordLink(String email) {
+    public SendCodeResponse sendPasswordResetLink(String email) {
         // 삭제되지 않은 사용자만
         User user = userRepository.findByEmail(email).orElse(null);
         if (user != null && !user.isDeleted()) {
@@ -203,14 +203,14 @@ public class AuthServiceV1 {
             );
 
             // 메일 전송
-            authMailService.sendResetPasswordLink(email, code);
+            authMailService.sendPasswordResetLink(email, code);
         }
 
         return new SendCodeResponse(email, LocalDateTime.now().plusMinutes(CODE_VALID_MINUTES));
     }
 
     @Transactional(readOnly = true)
-    public ConfirmCodeResponse confirmResetPasswordLink(String code) {
+    public ConfirmCodeResponse confirmPasswordResetLink(String code) {
         // 인증번호 조회
         return new ConfirmCodeResponse(getEmailByResetCode(code));
     }

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -135,10 +135,10 @@ public class AuthServiceV1 {
         String accessToken = jwtTokenProvider.createAccessToken(userId, role);
         String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        // Redis에 Refresh Token 저장
+        // Redis에 순수 Refresh Token 저장
         redisTemplate.opsForValue().set(
                 RT_PREFIX + userId,
-                refreshToken,
+                jwtTokenProvider.substringToken(refreshToken),
                 jwtTokenProvider.getRefreshTokenValidityDuration()
         );
 
@@ -153,17 +153,18 @@ public class AuthServiceV1 {
 
     public TokenResponse reissue(String refreshToken) {
         // 토큰 유효성 검사
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
+        String pureToken = jwtTokenProvider.substringToken(refreshToken);
+        if (pureToken == null || !jwtTokenProvider.validateToken(pureToken)) {
             throw new BaseException(AuthErrorCode.INVALID_TOKEN);
         }
 
         // userId 추출
-        UUID userId = jwtTokenProvider.getUserId(refreshToken);
+        UUID userId = jwtTokenProvider.getUserId(pureToken);
 
         // Refresh Token 조회
         String rtKey = RT_PREFIX + userId;
         String savedRefreshToken = redisTemplate.opsForValue().get(rtKey);
-        if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+        if (savedRefreshToken == null || !savedRefreshToken.equals(pureToken)) {
             throw new BaseException(AuthErrorCode.INVALID_TOKEN);
         }
 
@@ -173,10 +174,10 @@ public class AuthServiceV1 {
         String newAccessToken = jwtTokenProvider.createAccessToken(userId, user.getRole());
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        // Redis에 Refresh Token 저장
+        // Redis에 순수 Refresh Token 저장
         redisTemplate.opsForValue().set(
                 rtKey,
-                newRefreshToken,
+                jwtTokenProvider.substringToken(newRefreshToken),
                 jwtTokenProvider.getRefreshTokenValidityDuration()
         );
 
@@ -184,7 +185,7 @@ public class AuthServiceV1 {
     }
 
     public void logout(String userId) {
-        // Redis에서 Refresh Token 삭제
+        // Redis에서 순수 Refresh Token 삭제
         redisTemplate.delete(RT_PREFIX + userId);
     }
 

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -53,12 +53,18 @@ public class AuthServiceV1 {
         }
 
         // 사용자 생성 및 저장
-        User user = User.builder()
-                .email(email)
-                .password(passwordEncoder.encode(password))
-                .nickname(request.getNickname())
-                .role(request.getRole())
-                .build();
+        request.encryptPassword(passwordEncoder.encode(password));
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user != null) {
+            user.restore(request);
+        } else {
+            user = User.builder()
+                    .email(email)
+                    .password(request.getPassword())
+                    .nickname(request.getNickname())
+                    .role(request.getRole())
+                    .build();
+        }
         userRepository.save(user);
 
         // Redis에 이메일 인증 여부 삭제
@@ -69,12 +75,16 @@ public class AuthServiceV1 {
 
     public SendCodeResponse sendSignupCode(String email) {
         // 이메일 중복 확인
-        if (userRepository.existsByEmail(email)) {
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user != null && !user.isDeleted()) {
             throw new BaseException(UserErrorCode.DUPLICATE_EMAIL);
         }
 
         // 인증번호 생성
         String code = String.valueOf(ThreadLocalRandom.current().nextInt(100000, 1000000));
+
+        // 메일 전송
+        authMailService.sendSignupCode(email, code);
 
         // Redis에 인증번호 저장
         redisTemplate.opsForValue().set(
@@ -82,9 +92,6 @@ public class AuthServiceV1 {
                 code,
                 Duration.ofMinutes(CODE_VALID_MINUTES)
         );
-
-        // 메일 전송
-        authMailService.sendSignupCode(email, code);
 
         return new SendCodeResponse(email, LocalDateTime.now().plusMinutes(CODE_VALID_MINUTES));
     }

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -53,7 +53,7 @@ public class AuthServiceV1 {
         }
 
         // 사용자 생성 및 저장
-        request.encryptPassword(passwordEncoder.encode(password));
+        request.encodePassword(passwordEncoder.encode(password));
         User user = userRepository.findByEmail(email).orElse(null);
         if (user != null) {
             user.restore(request);
@@ -119,8 +119,10 @@ public class AuthServiceV1 {
 
     public LoginResponse login(String email, String password) {
         // 사용자 조회
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null || user.isDeleted()) {
+            throw new BaseException(UserErrorCode.USER_NOT_FOUND);
+        }
 
         // 비밀번호 일치 확인
         if (!passwordEncoder.matches(password, user.getPassword())) {
@@ -187,8 +189,9 @@ public class AuthServiceV1 {
     }
 
     public SendCodeResponse sendResetPasswordLink(String email) {
-        // 이메일 존재 시에만 수행
-        if (userRepository.existsByEmail(email)) {
+        // 삭제되지 않은 사용자만
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user != null && !user.isDeleted()) {
             // 인증번호 생성
             String code = UUID.randomUUID().toString();
 
@@ -222,9 +225,12 @@ public class AuthServiceV1 {
         }
 
         // 사용자 조회 및 비밀번호 변경
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null || user.isDeleted()) {
+            throw new BaseException(UserErrorCode.USER_NOT_FOUND);
+        }
         user.updatePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
 
         // Redis에 인증번호 삭제
         redisTemplate.delete(RESET_PASSWORD_PREFIX + code);

--- a/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/application/service/AuthServiceV1.java
@@ -11,7 +11,6 @@ import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
 import com.sparta.todayeats.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -175,12 +174,12 @@ public class AuthServiceV1 {
         return new TokenResponse(newAccessToken, newRefreshToken);
     }
 
-    public void logout(Authentication authentication) {
+    public void logout(String userId) {
         // Redis에서 Refresh Token 삭제
-        redisTemplate.delete(RT_PREFIX + authentication.getPrincipal());
+        redisTemplate.delete(RT_PREFIX + userId);
     }
 
-    public SendCodeResponse sendPasswordResetLink(String email) {
+    public SendCodeResponse sendResetPasswordLink(String email) {
         // 이메일 존재 시에만 수행
         if (userRepository.existsByEmail(email)) {
             // 인증번호 생성
@@ -201,12 +200,12 @@ public class AuthServiceV1 {
     }
 
     @Transactional(readOnly = true)
-    public ConfirmCodeResponse confirmPasswordResetLink(String code) {
+    public ConfirmCodeResponse confirmResetPasswordLink(String code) {
         // 인증번호 조회
         return new ConfirmCodeResponse(getEmailByResetCode(code));
     }
 
-    public PasswordResetResponse passwordReset(String code, String newPassword, String confirmPassword) {
+    public ResetPasswordResponse resetPassword(String code, String newPassword, String confirmPassword) {
         // 인증번호 조회
         String email = getEmailByResetCode(code);
 
@@ -223,7 +222,7 @@ public class AuthServiceV1 {
         // Redis에 인증번호 삭제
         redisTemplate.delete(RESET_PASSWORD_PREFIX + code);
 
-        return new PasswordResetResponse(user.getEmail(), user.getUpdatedAt());
+        return new ResetPasswordResponse(user.getEmail(), user.getUpdatedAt());
     }
 
     private String getEmailByResetCode(String code) {

--- a/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
@@ -47,13 +47,13 @@ public class AuthControllerV1 {
     }
 
     @PostMapping("/reset-password/send")
-    public ResponseEntity<SendCodeResponse> sendResetPasswordLink(@Valid @RequestBody SendCodeRequest request) {
-        return ResponseEntity.ok(authServiceV1.sendResetPasswordLink(request.getEmail()));
+    public ResponseEntity<SendCodeResponse> sendPasswordResetLink(@Valid @RequestBody SendCodeRequest request) {
+        return ResponseEntity.ok(authServiceV1.sendPasswordResetLink(request.getEmail()));
     }
 
     @GetMapping("/reset-password")
-    public ResponseEntity<ConfirmCodeResponse> confirmResetPasswordLink(@RequestParam String code) {
-        return ResponseEntity.ok(authServiceV1.confirmResetPasswordLink(code));
+    public ResponseEntity<ConfirmCodeResponse> confirmPasswordResetLink(@RequestParam String code) {
+        return ResponseEntity.ok(authServiceV1.confirmPasswordResetLink(code));
     }
 
     @PatchMapping("/reset-password")

--- a/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/controller/AuthControllerV1.java
@@ -42,24 +42,24 @@ public class AuthControllerV1 {
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(Authentication authentication) {
-        authServiceV1.logout(authentication);
+        authServiceV1.logout(authentication.getName());
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/password-reset/send")
-    public ResponseEntity<SendCodeResponse> sendPasswordResetLink(@Valid @RequestBody SendCodeRequest request) {
-        return ResponseEntity.ok(authServiceV1.sendPasswordResetLink(request.getEmail()));
+    @PostMapping("/reset-password/send")
+    public ResponseEntity<SendCodeResponse> sendResetPasswordLink(@Valid @RequestBody SendCodeRequest request) {
+        return ResponseEntity.ok(authServiceV1.sendResetPasswordLink(request.getEmail()));
     }
 
-    @GetMapping("/password-reset")
-    public ResponseEntity<ConfirmCodeResponse> confirmPasswordResetLink(@RequestParam String code) {
-        return ResponseEntity.ok(authServiceV1.confirmPasswordResetLink(code));
+    @GetMapping("/reset-password")
+    public ResponseEntity<ConfirmCodeResponse> confirmResetPasswordLink(@RequestParam String code) {
+        return ResponseEntity.ok(authServiceV1.confirmResetPasswordLink(code));
     }
 
-    @PatchMapping("/password-reset")
-    public ResponseEntity<PasswordResetResponse> passwordReset(
-            @RequestParam String code, @Valid @RequestBody PasswordResetRequest request
+    @PatchMapping("/reset-password")
+    public ResponseEntity<ResetPasswordResponse> resetPassword(
+            @RequestParam String code, @Valid @RequestBody ResetPasswordRequest request
     ) {
-        return ResponseEntity.ok(authServiceV1.passwordReset(code, request.getNewPassword(), request.getConfirmPassword()));
+        return ResponseEntity.ok(authServiceV1.resetPassword(code, request.getNewPassword(), request.getConfirmPassword()));
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ConfirmCodeRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ConfirmCodeRequest.java
@@ -3,11 +3,12 @@ package com.sparta.todayeats.auth.presentation.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ConfirmCodeRequest {
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/LoginRequest.java
@@ -1,11 +1,12 @@
 package com.sparta.todayeats.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginRequest {
     @NotBlank(message = "이메일은 필수입니다.")
     private String email;

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/RefreshTokenRequest.java
@@ -1,9 +1,12 @@
 package com.sparta.todayeats.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshTokenRequest {
     @NotBlank(message = "리프레시 토큰은 필수입니다.")
     private String refreshToken;

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ResetPasswordRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class PasswordResetRequest {
+public class ResetPasswordRequest {
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/ResetPasswordRequest.java
@@ -2,11 +2,12 @@ package com.sparta.todayeats.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResetPasswordRequest {
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Pattern(

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SendCodeRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SendCodeRequest.java
@@ -2,11 +2,12 @@ package com.sparta.todayeats.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SendCodeRequest {
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
@@ -2,11 +2,12 @@ package com.sparta.todayeats.auth.presentation.dto.request;
 
 import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
 import jakarta.validation.constraints.*;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignupRequest {
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
@@ -35,7 +35,7 @@ public class SignupRequest {
         return role == UserRoleEnum.CUSTOMER || role == UserRoleEnum.OWNER;
     }
 
-    public void encryptPassword(String encodedPassword) {
+    public void encodePassword(String encodedPassword) {
         this.password = encodedPassword;
     }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/request/SignupRequest.java
@@ -34,4 +34,8 @@ public class SignupRequest {
     public boolean isValidRole() {
         return role == UserRoleEnum.CUSTOMER || role == UserRoleEnum.OWNER;
     }
+
+    public void encryptPassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/ResetPasswordResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/ResetPasswordResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class PasswordResetResponse {
+public class ResetPasswordResponse {
     private String email;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
@@ -1,7 +1,6 @@
 package com.sparta.todayeats.auth.presentation.dto.response;
 
 import com.sparta.todayeats.user.domain.entity.User;
-import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
 import lombok.Getter;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
+++ b/src/main/java/com/sparta/todayeats/auth/presentation/dto/response/SignupResponse.java
@@ -10,13 +10,13 @@ import java.time.LocalDateTime;
 public class SignupResponse {
     private final String email;
     private final String nickname;
-    private final UserRoleEnum role;
+    private final String role;
     private final LocalDateTime createdAt;
 
     public SignupResponse(User user) {
         this.email = user.getEmail();
         this.nickname = user.getNickname();
-        this.role = user.getRole();
+        this.role = user.getRole().name();
         this.createdAt = user.getCreatedAt();
     }
 }

--- a/src/main/java/com/sparta/todayeats/global/annotation/LoginUser.java
+++ b/src/main/java/com/sparta/todayeats/global/annotation/LoginUser.java
@@ -1,0 +1,11 @@
+package com.sparta.todayeats.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER) // 파라미터에만 사용
+@Retention(RetentionPolicy.RUNTIME) // 런타임까지 유지
+public @interface LoginUser {
+}

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/config/WebConfig.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.todayeats.global.infrastructure.config;
+
+import com.sparta.todayeats.global.resolver.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/config/security/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.sparta.todayeats.global.infrastructure.config.security;
 
-import com.sparta.todayeats.global.infrastructure.config.security.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,7 +18,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
 
     @Override
     protected void doFilterInternal(
@@ -38,14 +36,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    // 토큰 추출
+    // Token 추출
     private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-
-        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(7);
-        }
-
-        return null;
+        return jwtTokenProvider.substringToken(request.getHeader(AUTHORIZATION_HEADER));
     }
 }

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/config/security/JwtTokenProvider.java
@@ -25,6 +25,8 @@ public class JwtTokenProvider {
     private final long accessTokenValidity;
     private final long refreshTokenValidity;
 
+    private static final String BEARER_PREFIX = "Bearer ";
+
     private static final String TOKEN_TYPE = "tokenType";
     private static final String ROLE = "role";
     private static final String ACCESS = "access";
@@ -39,6 +41,14 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.accessTokenValidity = accessTokenValidity;
         this.refreshTokenValidity = refreshTokenValidity;
+    }
+
+    // Token 분리
+    public String substringToken(String token) {
+        if (token != null && token.startsWith(BEARER_PREFIX)) {
+            return token.substring(BEARER_PREFIX.length());
+        }
+        return null;
     }
 
     // Access Token 생성
@@ -67,7 +77,7 @@ public class JwtTokenProvider {
             builder.claim(ROLE, role.getAuthority());
         }
 
-        return builder.compact();
+        return BEARER_PREFIX + builder.compact();
     }
 
     // Authentication 생성

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/entity/BaseEntity.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/entity/BaseEntity.java
@@ -35,6 +35,11 @@ public abstract class BaseEntity {
 
     private UUID deletedBy;
 
+    public void restore() {
+        this.deletedAt = null;
+        this.deletedBy = null;
+    }
+
     public void softDelete(UUID userId) {
         if (this.deletedAt == null) {
             this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/sparta/todayeats/global/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/sparta/todayeats/global/resolver/LoginUserArgumentResolver.java
@@ -27,11 +27,11 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+        Object principal = authentication.getPrincipal();
+        if (principal == null || "anonymousUser".equals(principal)) {
             return null;
         }
 
-        Object principal = authentication.getPrincipal();
         if (principal instanceof UUID) {
             return principal;
         }

--- a/src/main/java/com/sparta/todayeats/global/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/sparta/todayeats/global/resolver/LoginUserArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.sparta.todayeats.global.resolver;
+
+import com.sparta.todayeats.global.annotation.LoginUser;
+import com.sparta.todayeats.global.exception.AuthErrorCode;
+import com.sparta.todayeats.global.exception.BaseException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.UUID;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class) &&
+                parameter.getParameterType().equals(UUID.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UUID) {
+            return principal;
+        }
+
+        throw new BaseException(AuthErrorCode.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/sparta/todayeats/global/service/UserAuthorizationService.java
+++ b/src/main/java/com/sparta/todayeats/global/service/UserAuthorizationService.java
@@ -1,0 +1,61 @@
+package com.sparta.todayeats.global.service;
+
+import com.sparta.todayeats.global.exception.AuthErrorCode;
+import com.sparta.todayeats.global.exception.BaseException;
+import com.sparta.todayeats.global.exception.UserErrorCode;
+import com.sparta.todayeats.user.domain.entity.User;
+import com.sparta.todayeats.user.domain.entity.UserRoleEnum;
+import com.sparta.todayeats.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserAuthorizationService {
+    private final UserRepository userRepository;
+
+    public User getUserById(UUID userId) {
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    // 권한 검증
+    public void validateMaster(User user) {
+        if (!isMaster(user)) {
+            throw new BaseException(AuthErrorCode.FORBIDDEN);
+        }
+    }
+
+    public void validateAdmin(User user) {
+        if (!isAdmin(user)) {
+            throw new BaseException(AuthErrorCode.FORBIDDEN);
+        }
+    }
+
+    public void validateSelf(UUID targetUserId, UUID currentUserId) {
+        if (!targetUserId.equals(currentUserId)) {
+            throw new BaseException(AuthErrorCode.FORBIDDEN);
+        }
+    }
+
+    // 권한 확인
+    public boolean isOwner(User user) {
+        return user.getRole() == UserRoleEnum.OWNER;
+    }
+
+    public boolean isMaster(User user) {
+        return user.getRole() == UserRoleEnum.MASTER;
+    }
+
+    public boolean isManager(User user) {
+        return user.getRole() == UserRoleEnum.MANAGER;
+    }
+
+    public boolean isAdmin(User user) {
+        return isMaster(user) || isManager(user);
+    }
+}

--- a/src/main/java/com/sparta/todayeats/user/domain/entity/User.java
+++ b/src/main/java/com/sparta/todayeats/user/domain/entity/User.java
@@ -1,5 +1,6 @@
 package com.sparta.todayeats.user.domain.entity;
 
+import com.sparta.todayeats.auth.presentation.dto.request.SignupRequest;
 import com.sparta.todayeats.global.infrastructure.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -43,5 +44,12 @@ public class User extends BaseEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void restore(SignupRequest request) {
+        this.password = request.getPassword();
+        this.nickname = request.getNickname();
+        this.role = request.getRole();
+        this.restore();
     }
 }

--- a/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/todayeats/user/domain/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    Optional<User> findByUserId(UUID userId);
 }

--- a/src/main/resources/templates/todayeats-auth-email.html
+++ b/src/main/resources/templates/todayeats-auth-email.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -78,15 +78,15 @@
 
     <div class="logo">오늘한끼</div>
 
-    <h2>${title}</h2>
+    <h2 th:text="${title}">메일 제목</h2>
 
-    <p>${description}</p>
+    <p th:text="${description}">메일 상세 설명</p>
 
-    <!-- 인증 코드 -->
-    <div class="code-box">${code}</div>
+    <!-- 인증번호 -->
+    <div th:if="${code != null}" class="code-box" th:text="${code}">인증번호</div>
 
     <!-- 비밀번호 재설정 링크 -->
-    <a href="${resetLink}" class="button">비밀번호 재설정하기</a>
+    <a th:if="${resetLink != null}" th:href="${resetLink}" class="button">비밀번호 재설정</a>
 
     <p class="footer">
         이 인증 정보는 <strong>5분</strong> 동안 유효합니다.<br/>

--- a/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
+++ b/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
@@ -67,8 +67,9 @@ class AuthServiceV1Test {
     private static final String NICKNAME = "nick";
     private static final String CODE = "123456";
 
-    private static final String ACCESS_TOKEN = "access-token";
-    private static final String REFRESH_TOKEN = "refresh-token";
+    private static final String ACCESS_TOKEN = "Bearer access-token";
+    private static final String REFRESH_TOKEN = "Bearer refresh-token";
+    private static final String PURE_REFRESH_TOKEN = "refresh-token";
 
     private static final String RT_KEY = RT_PREFIX + USER_ID;
 
@@ -161,6 +162,7 @@ class AuthServiceV1Test {
 
             // then
             assertThat(response.getEmail()).isEqualTo(EMAIL);
+            verify(valueOperations).set(eq(SIGNUP_PREFIX + EMAIL), anyString(), any(Duration.class));
             verify(authMailService).sendSignupCode(eq(EMAIL), anyString());
         }
 
@@ -241,7 +243,7 @@ class AuthServiceV1Test {
             given(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).willReturn(true);
             given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(ACCESS_TOKEN);
             given(jwtTokenProvider.createRefreshToken(any())).willReturn(REFRESH_TOKEN);
-            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(PURE_REFRESH_TOKEN);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(jwtTokenProvider.getRefreshTokenValidityDuration()).willReturn(Duration.ofDays(7));
 
@@ -251,7 +253,7 @@ class AuthServiceV1Test {
             // then
             assertThat(response).isNotNull();
             assertThat(response.getAccessToken()).isEqualTo(ACCESS_TOKEN);
-            verify(redisTemplate.opsForValue()).set(startsWith(RT_PREFIX), eq(REFRESH_TOKEN), any());
+            verify(redisTemplate.opsForValue()).set(startsWith(RT_PREFIX), eq(PURE_REFRESH_TOKEN), any());
         }
 
         @Test
@@ -300,17 +302,18 @@ class AuthServiceV1Test {
         @Test
         void 토큰_재발급_성공() {
             // given
-            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
-            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
-            given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
+            given(jwtTokenProvider.validateToken(PURE_REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(PURE_REFRESH_TOKEN);
+            given(jwtTokenProvider.getUserId(PURE_REFRESH_TOKEN)).willReturn(USER_ID);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get(RT_KEY)).willReturn(REFRESH_TOKEN);
+            given(valueOperations.get(RT_KEY)).willReturn(PURE_REFRESH_TOKEN);
 
             User user = User.builder().email(EMAIL).role(UserRoleEnum.CUSTOMER).build();
 
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
             given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(ACCESS_TOKEN);
             given(jwtTokenProvider.createRefreshToken(any())).willReturn(REFRESH_TOKEN);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(PURE_REFRESH_TOKEN);
             given(jwtTokenProvider.getRefreshTokenValidityDuration()).willReturn(Duration.ofDays(7));
 
             // when
@@ -319,14 +322,14 @@ class AuthServiceV1Test {
             // then
             assertThat(response.getAccessToken()).isEqualTo(ACCESS_TOKEN);
             assertThat(response.getRefreshToken()).isEqualTo(REFRESH_TOKEN);
-            verify(valueOperations).set(eq(RT_KEY), eq(REFRESH_TOKEN), any());
+            verify(valueOperations).set(eq(RT_KEY), eq(PURE_REFRESH_TOKEN), any());
         }
 
         @Test
         void 토큰_재발급_실패_토큰_미유효() {
             // given
-            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
-            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(false);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(PURE_REFRESH_TOKEN);
+            given(jwtTokenProvider.validateToken(PURE_REFRESH_TOKEN)).willReturn(false);
 
             // when & then
             assertThatThrownBy(() -> authServiceV1.reissue(REFRESH_TOKEN))
@@ -337,9 +340,9 @@ class AuthServiceV1Test {
         @Test
         void 토큰_재발급_실패_토큰_불일치() {
             // given
-            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
-            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
-            given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
+            given(jwtTokenProvider.validateToken(PURE_REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(PURE_REFRESH_TOKEN);
+            given(jwtTokenProvider.getUserId(PURE_REFRESH_TOKEN)).willReturn(USER_ID);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(RT_KEY)).willReturn("other-token");
 
@@ -352,11 +355,11 @@ class AuthServiceV1Test {
         @Test
         void 토큰_재발급_실패_사용자_없음() {
             // given
-            given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
-            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
-            given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
+            given(jwtTokenProvider.validateToken(PURE_REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(PURE_REFRESH_TOKEN);
+            given(jwtTokenProvider.getUserId(PURE_REFRESH_TOKEN)).willReturn(USER_ID);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get(RT_KEY)).willReturn(REFRESH_TOKEN);
+            given(valueOperations.get(RT_KEY)).willReturn(PURE_REFRESH_TOKEN);
             given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
 
             // when & then

--- a/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
+++ b/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
@@ -108,7 +108,7 @@ class AuthServiceV1Test {
         @Test
         void 회원가입_실패_비밀번호_불일치() {
             // given
-            SignupRequest request = signupRequest("12345");
+            SignupRequest request = signupRequest("WRONG");
 
             given(redisTemplate.hasKey(VERIFIED_PREFIX + EMAIL)).willReturn(true);
 
@@ -133,9 +133,9 @@ class AuthServiceV1Test {
     @DisplayName("sendSignupCode()")
     class SendSignupCode {
         @Test
-        void 인증번호_전송_성공() {
+        void 인증번호_전송_성공_신규() {
             // given
-            given(userRepository.existsByEmail(EMAIL)).willReturn(false);
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
             // when
@@ -143,18 +143,37 @@ class AuthServiceV1Test {
 
             // then
             assertThat(response.getEmail()).isEqualTo(EMAIL);
-            verify(redisTemplate.opsForValue()).set(
-                    startsWith(SIGNUP_PREFIX),
+            verify(valueOperations).set(
+                    eq(SIGNUP_PREFIX + EMAIL),
                     anyString(),
-                    any()
+                    any(Duration.class)
             );
+            verify(authMailService).sendSignupCode(eq(EMAIL), anyString());
+        }
+
+        @Test
+        void 인증번호_전송_성공_기존() {
+            // given
+            User user = User.builder().email(EMAIL).build();
+            user.softDelete(USER_ID);
+
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+            // when
+            SendCodeResponse response = authServiceV1.sendSignupCode(EMAIL);
+
+            // then
+            assertThat(response.getEmail()).isEqualTo(EMAIL);
             verify(authMailService).sendSignupCode(eq(EMAIL), anyString());
         }
 
         @Test
         void 인증번호_전송_실패() {
             // given
-            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            User activeUser = User.builder().email(EMAIL).build();
+
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(activeUser));
 
             // when & then
             assertThatThrownBy(() -> authServiceV1.sendSignupCode(EMAIL))
@@ -191,23 +210,25 @@ class AuthServiceV1Test {
         @Test
         void 인증번호_검증_실패_인증번호_없음() {
             // given
-            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(SIGNUP_PREFIX + EMAIL)).willReturn(null);
 
             // when & then
-            assertThatThrownBy(() -> authServiceV1.sendSignupCode(EMAIL))
+            assertThatThrownBy(() -> authServiceV1.confirmSignupCode(EMAIL, CODE))
                     .isInstanceOf(BaseException.class)
-                    .hasMessage(UserErrorCode.DUPLICATE_EMAIL.getMessage());
+                    .hasMessage(AuthErrorCode.INVALID_VERIFICATION_CODE.getMessage());
         }
 
         @Test
         void 인증번호_검증_실패_인증번호_불일치() {
             // given
-            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(SIGNUP_PREFIX + EMAIL)).willReturn("WRONG");
 
             // when & then
-            assertThatThrownBy(() -> authServiceV1.sendSignupCode(EMAIL))
+            assertThatThrownBy(() -> authServiceV1.confirmSignupCode(EMAIL, CODE))
                     .isInstanceOf(BaseException.class)
-                    .hasMessage(UserErrorCode.DUPLICATE_EMAIL.getMessage());
+                    .hasMessage(AuthErrorCode.INVALID_VERIFICATION_CODE.getMessage());
         }
     }
 

--- a/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
+++ b/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
@@ -108,7 +108,7 @@ class AuthServiceV1Test {
         @Test
         void 회원가입_실패_비밀번호_불일치() {
             // given
-            SignupRequest request = signupRequest("WRONG");
+            SignupRequest request = signupRequest("wrong");
 
             given(redisTemplate.hasKey(VERIFIED_PREFIX + EMAIL)).willReturn(true);
 
@@ -143,11 +143,7 @@ class AuthServiceV1Test {
 
             // then
             assertThat(response.getEmail()).isEqualTo(EMAIL);
-            verify(valueOperations).set(
-                    eq(SIGNUP_PREFIX + EMAIL),
-                    anyString(),
-                    any(Duration.class)
-            );
+            verify(valueOperations).set(eq(SIGNUP_PREFIX + EMAIL), anyString(), any(Duration.class));
             verify(authMailService).sendSignupCode(eq(EMAIL), anyString());
         }
 
@@ -200,11 +196,7 @@ class AuthServiceV1Test {
             // then
             assertThat(response.getEmail()).isEqualTo(EMAIL);
             verify(redisTemplate).delete(signupKey);
-            verify(valueOperations).set(
-                    eq(verifiedKey),
-                    eq("true"),
-                    any()
-            );
+            verify(valueOperations).set(eq(verifiedKey), eq("true"), any());
         }
 
         @Test
@@ -223,7 +215,7 @@ class AuthServiceV1Test {
         void 인증번호_검증_실패_인증번호_불일치() {
             // given
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get(SIGNUP_PREFIX + EMAIL)).willReturn("WRONG");
+            given(valueOperations.get(SIGNUP_PREFIX + EMAIL)).willReturn("wrong");
 
             // when & then
             assertThatThrownBy(() -> authServiceV1.confirmSignupCode(EMAIL, CODE))
@@ -258,11 +250,7 @@ class AuthServiceV1Test {
             // then
             assertThat(response).isNotNull();
             assertThat(response.getAccessToken()).isEqualTo(ACCESS_TOKEN);
-            verify(redisTemplate.opsForValue()).set(
-                    startsWith(RT_PREFIX),
-                    eq(REFRESH_TOKEN),
-                    any()
-            );
+            verify(redisTemplate.opsForValue()).set(startsWith(RT_PREFIX), eq(REFRESH_TOKEN), any());
         }
 
         @Test
@@ -277,12 +265,23 @@ class AuthServiceV1Test {
         }
 
         @Test
+        void 로그인_실패_삭제된_사용자() {
+            // given
+            User user = User.builder().email(EMAIL).build();
+            user.softDelete(USER_ID);
+
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.login(EMAIL, PASSWORD))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
         void 로그인_실패_비밀번호_불일치() {
             // given
-            User user = User.builder()
-                    .email(EMAIL)
-                    .password(ENCODED_PASSWORD)
-                    .build();
+            User user = User.builder().email(EMAIL).password(ENCODED_PASSWORD).build();
 
             given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
             given(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).willReturn(false);
@@ -305,10 +304,7 @@ class AuthServiceV1Test {
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(RT_KEY)).willReturn(REFRESH_TOKEN);
 
-            User user = User.builder()
-                    .email(EMAIL)
-                    .role(UserRoleEnum.CUSTOMER)
-                    .build();
+            User user = User.builder().email(EMAIL).role(UserRoleEnum.CUSTOMER).build();
 
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
             given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(ACCESS_TOKEN);
@@ -321,11 +317,7 @@ class AuthServiceV1Test {
             // then
             assertThat(response.getAccessToken()).isEqualTo(ACCESS_TOKEN);
             assertThat(response.getRefreshToken()).isEqualTo(REFRESH_TOKEN);
-            verify(valueOperations).set(
-                    eq(RT_KEY),
-                    eq(REFRESH_TOKEN),
-                    any()
-            );
+            verify(valueOperations).set(eq(RT_KEY), eq(REFRESH_TOKEN), any());
         }
 
         @Test
@@ -354,7 +346,7 @@ class AuthServiceV1Test {
         }
 
         @Test
-        void 토큰재발급_실패_사용자_없음() {
+        void 토큰_재발급_실패_사용자_없음() {
             // given
             given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
             given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
@@ -385,9 +377,11 @@ class AuthServiceV1Test {
 
     @Test
     @DisplayName("sendResetPasswordLink()")
-    void 재설정_링크_전송_성공() {
+    void 비밀번호_재설정_링크_전송_성공() {
         // given
-        given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+        User user = User.builder().email(EMAIL).build();
+
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
         // when
@@ -395,11 +389,7 @@ class AuthServiceV1Test {
 
         // then
         assertThat(response.getEmail()).isEqualTo(EMAIL);
-        verify(valueOperations).set(
-                startsWith(RESET_PASSWORD_PREFIX),
-                eq(EMAIL),
-                any()
-        );
+        verify(valueOperations).set(startsWith(RESET_PASSWORD_PREFIX), eq(EMAIL), any());
         verify(authMailService).sendResetPasswordLink(eq(EMAIL), anyString());
     }
 
@@ -414,10 +404,7 @@ class AuthServiceV1Test {
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(resetKey())).willReturn(EMAIL);
 
-            User user = User.builder()
-                    .email(EMAIL)
-                    .password("encoded-old")
-                    .build();
+            User user = User.builder().email(EMAIL).password("encoded-old").build();
 
             given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
             given(passwordEncoder.encode(NEW_PASSWORD)).willReturn("encoded-new");
@@ -432,7 +419,7 @@ class AuthServiceV1Test {
         }
 
         @Test
-        void 비밀번호_재설정_실패_코드없음() {
+        void 비밀번호_재설정_실패_인증번호_없음() {
             // given
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(resetKey())).willReturn(null);
@@ -456,13 +443,28 @@ class AuthServiceV1Test {
         }
 
         @Test
-        void 비밀번호재설정_실패_사용자_없음() {
+        void 비밀번호_재설정_실패_사용자_없음() {
+            // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(resetKey())).willReturn(EMAIL);
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authServiceV1.resetPassword(CODE, NEW_PASSWORD, NEW_PASSWORD))
+                    .isInstanceOf(BaseException.class)
+                    .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 비밀번호_재설정_실패_삭제된_사용자() {
             // given
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(resetKey())).willReturn(EMAIL);
 
-            given(userRepository.findByEmail(EMAIL))
-                    .willReturn(Optional.empty());
+            User user = User.builder().email(EMAIL).build();
+            user.softDelete(USER_ID);
+
+            given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
 
             // when & then
             assertThatThrownBy(() -> authServiceV1.resetPassword(CODE, NEW_PASSWORD, NEW_PASSWORD))

--- a/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
+++ b/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
@@ -385,12 +385,12 @@ class AuthServiceV1Test {
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
         // when
-        SendCodeResponse response = authServiceV1.sendResetPasswordLink(EMAIL);
+        SendCodeResponse response = authServiceV1.sendPasswordResetLink(EMAIL);
 
         // then
         assertThat(response.getEmail()).isEqualTo(EMAIL);
         verify(valueOperations).set(startsWith(RESET_PASSWORD_PREFIX), eq(EMAIL), any());
-        verify(authMailService).sendResetPasswordLink(eq(EMAIL), anyString());
+        verify(authMailService).sendPasswordResetLink(eq(EMAIL), anyString());
     }
 
     @Nested

--- a/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
+++ b/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
@@ -241,6 +241,7 @@ class AuthServiceV1Test {
             given(passwordEncoder.matches(PASSWORD, ENCODED_PASSWORD)).willReturn(true);
             given(jwtTokenProvider.createAccessToken(any(), any())).willReturn(ACCESS_TOKEN);
             given(jwtTokenProvider.createRefreshToken(any())).willReturn(REFRESH_TOKEN);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(jwtTokenProvider.getRefreshTokenValidityDuration()).willReturn(Duration.ofDays(7));
 
@@ -300,6 +301,7 @@ class AuthServiceV1Test {
         void 토큰_재발급_성공() {
             // given
             given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
             given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(RT_KEY)).willReturn(REFRESH_TOKEN);
@@ -323,6 +325,7 @@ class AuthServiceV1Test {
         @Test
         void 토큰_재발급_실패_토큰_미유효() {
             // given
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
             given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(false);
 
             // when & then
@@ -335,6 +338,7 @@ class AuthServiceV1Test {
         void 토큰_재발급_실패_토큰_불일치() {
             // given
             given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
             given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(RT_KEY)).willReturn("other-token");
@@ -349,6 +353,7 @@ class AuthServiceV1Test {
         void 토큰_재발급_실패_사용자_없음() {
             // given
             given(jwtTokenProvider.validateToken(REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.substringToken(REFRESH_TOKEN)).willReturn(REFRESH_TOKEN);
             given(jwtTokenProvider.getUserId(REFRESH_TOKEN)).willReturn(USER_ID);
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get(RT_KEY)).willReturn(REFRESH_TOKEN);
@@ -366,7 +371,7 @@ class AuthServiceV1Test {
     void 로그아웃_성공() {
         // given
         Authentication authentication = mock(Authentication.class);
-        given(authentication.getPrincipal()).willReturn(USER_ID.toString());
+        given(authentication.getName()).willReturn(USER_ID.toString());
 
         // when
         authServiceV1.logout(authentication.getName());

--- a/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
+++ b/src/test/java/com/sparta/todayeats/auth/application/service/AuthServiceV1Test.java
@@ -356,21 +356,21 @@ class AuthServiceV1Test {
         given(authentication.getPrincipal()).willReturn(USER_ID.toString());
 
         // when
-        authServiceV1.logout(authentication);
+        authServiceV1.logout(authentication.getName());
 
         // then
         verify(redisTemplate).delete(RT_KEY);
     }
 
     @Test
-    @DisplayName("sendPasswordResetLink()")
+    @DisplayName("sendResetPasswordLink()")
     void 재설정_링크_전송_성공() {
         // given
         given(userRepository.existsByEmail(EMAIL)).willReturn(true);
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
         // when
-        SendCodeResponse response = authServiceV1.sendPasswordResetLink(EMAIL);
+        SendCodeResponse response = authServiceV1.sendResetPasswordLink(EMAIL);
 
         // then
         assertThat(response.getEmail()).isEqualTo(EMAIL);
@@ -383,8 +383,8 @@ class AuthServiceV1Test {
     }
 
     @Nested
-    @DisplayName("passwordReset()")
-    class PasswordReset {
+    @DisplayName("resetPassword()")
+    class ResetPassword {
         private final String NEW_PASSWORD = "decoded-new";
 
         @Test
@@ -402,7 +402,7 @@ class AuthServiceV1Test {
             given(passwordEncoder.encode(NEW_PASSWORD)).willReturn("encoded-new");
 
             // when
-            PasswordResetResponse response = authServiceV1.passwordReset(CODE, NEW_PASSWORD, NEW_PASSWORD);
+            ResetPasswordResponse response = authServiceV1.resetPassword(CODE, NEW_PASSWORD, NEW_PASSWORD);
 
             // then
             assertThat(response.getEmail()).isEqualTo(EMAIL);
@@ -417,7 +417,7 @@ class AuthServiceV1Test {
             given(valueOperations.get(resetKey())).willReturn(null);
 
             // when & then
-            assertThatThrownBy(() -> authServiceV1.passwordReset(CODE, NEW_PASSWORD, NEW_PASSWORD))
+            assertThatThrownBy(() -> authServiceV1.resetPassword(CODE, NEW_PASSWORD, NEW_PASSWORD))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(AuthErrorCode.INVALID_VERIFICATION_CODE.getMessage());
         }
@@ -429,7 +429,7 @@ class AuthServiceV1Test {
             given(valueOperations.get(resetKey())).willReturn(EMAIL);
 
             // when & then
-            assertThatThrownBy(() -> authServiceV1.passwordReset(CODE, "a", "b"))
+            assertThatThrownBy(() -> authServiceV1.resetPassword(CODE, "a", "b"))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(UserErrorCode.PASSWORD_MISMATCH.getMessage());
         }
@@ -444,7 +444,7 @@ class AuthServiceV1Test {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> authServiceV1.passwordReset(CODE, NEW_PASSWORD, NEW_PASSWORD))
+            assertThatThrownBy(() -> authServiceV1.resetPassword(CODE, NEW_PASSWORD, NEW_PASSWORD))
                     .isInstanceOf(BaseException.class)
                     .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
         }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,3 +1,8 @@
+app:
+  url:
+    base: http://localhost:8080
+    password-reset-path: /api/v1/auth/reset-password
+
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/todayeats


### PR DESCRIPTION
## 📌 관련 이슈
#34 


## ✨ 요약
삭제된 사용자 대응 및 권한 검증 서비스 구현

- 회원가입 시 삭제된 사용자 재가입 로직 추가
- 로그인 및 비밀번호 재설정 시 삭제된 사용자 검증 로직 추가
- `@LoginUser` 생성
- LoginUserArgumentResolver 구현 및 등록
- UserAuthorizationService 구현

## 상세 내용
### 사용자 검증 로직 강화
- **재가입 처리**: 회원가입 시 기존 계정 활성화
- **접근 제한**: 로그인 및 비밀번호 재설정 시 `USER_NOT_FOUND` 에러
### `@LoginUser`
컨트롤러 파라미터에서 SecurityContext에서 추출한 인증 객체의 UUID 주입
### LoginUserArgumentResolver
`@LoginUser`이 붙은 파라미터에 대해 실제 인증 객체를 바인딩하는 공통 로직 처리
### UserAuthorizationService
사용자의 접근 권한을 통합적으로 담당하는 서비스


## 📸 스크린샷(선택)
- 없음


## 📚 레퍼런스  혹은 궁금한 사항들
- Auth 통합 테스트 완료
- `@LoginUser` 테스트 필요

Closes #34 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTML email templating added for auth emails (Thymeleaf) and signup/reset templates updated
  * Parameter injection support for controllers via a new annotation and Web MVC config
  * User authorization helpers and entity restore support

* **Improvements**
  * Password reset endpoints and flows refined; reset links built from configured base URL
  * Tokens standardized with Bearer prefix; logout/reissue flows simplified

* **Refactor**
  * DTO/response renames, constructor additions, and minor response field type change

* **Tests**
  * Auth tests updated to reflect new flows and behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->