### PR TITLE
[feat] 카테고리, 운영지역, 가게 JWT 인증 연동

### DIFF
--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -135,9 +135,9 @@ public class AreaService {
         return areaRepository.findByNameContainingIgnoreCase(keyword, pageable);
     }
 
-    // 운영 지역 이름 기준 중복 조회 (대소문자 상관없이 존재 여부 확인)
+    // 운영 지역 이름 중복 여부 확인 (삭제 안 된 것만 중복 체크)
     private void validateDuplicateArea(String name) {
-        if (areaRepository.existsByNameIgnoreCase(name)) {
+        if (areaRepository.existsByNameIgnoreCaseAndDeletedAtIsNull(name)) {
             throw new BaseException(AreaErrorCode.AREA_ALREADY_EXISTS);
         }
     }

--- a/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/application/service/AreaService.java
@@ -121,9 +121,9 @@ public class AreaService {
 
     // 운영 지역 삭제
     @Transactional
-    public void deleteArea(UUID areaId) {
+    public void deleteArea(UUID areaId, UUID userId) {
         Area area = getAreaEntity(areaId);
-        area.softDelete(null);
+        area.softDelete(userId);
     }
 
 

--- a/src/main/java/com/sparta/todayeats/area/domain/entity/Area.java
+++ b/src/main/java/com/sparta/todayeats/area/domain/entity/Area.java
@@ -8,12 +8,15 @@ import org.hibernate.annotations.Where;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_area")
 @Getter
 @Builder
 @AllArgsConstructor
 @Where(clause = "deleted_at is null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "p_area",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deleted_at"})
+)
 public class Area extends BaseEntity {
 
     @Id
@@ -21,7 +24,7 @@ public class Area extends BaseEntity {
     @Column(name = "area_id")
     private UUID id;
 
-    @Column(nullable = false, length = 100, unique = true)
+    @Column(nullable = false, length = 100)
     private String name;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
+++ b/src/main/java/com/sparta/todayeats/area/domain/repository/AreaRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface AreaRepository extends JpaRepository<Area, UUID> {
     // 운영지역 이름 중복 여부 확인 (대소문자 무시)
-    boolean existsByNameIgnoreCase(String name);
+    boolean existsByNameIgnoreCaseAndDeletedAtIsNull(String name);
 
     // 운영지역 이름 기준 부분 일치(대소문자 무시) 검색 + 페이징 조회
     Page<Area> findByNameContainingIgnoreCase(String name, Pageable pageable);

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -5,6 +5,7 @@ import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
 import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
 import com.sparta.todayeats.area.presentation.dto.AreaResponse;
 import com.sparta.todayeats.area.presentation.dto.AreaUpdateRequest;
+import com.sparta.todayeats.global.annotation.LoginUser;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -72,7 +73,7 @@ public class AreaController {
     // 운영 지역 삭제
     @PreAuthorize("hasAnyRole('MASTER')")
     @DeleteMapping("/{areaId}")
-    public ResponseEntity<ApiResponse<Void>> deleteArea(@PathVariable UUID areaId,@AuthenticationPrincipal UUID userId) {
+    public ResponseEntity<ApiResponse<Void>> deleteArea(@PathVariable UUID areaId,@LoginUser UUID userId) {
 
         areaService.deleteArea(areaId,userId);
 

--- a/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/presentation/controller/AreaController.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -25,9 +27,9 @@ public class AreaController {
 
     private final AreaService areaService;
 
-    // TODO: 권한 처리(MANAGER, MASTER), Auditing
     // 운영 지역 생성
     @PostMapping
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     public ResponseEntity<ApiResponse<AreaCreateResponse>> createArea(@Valid @RequestBody AreaCreateRequest request) {
         AreaCreateResponse response = areaService.createArea(request);
 
@@ -36,7 +38,6 @@ public class AreaController {
                 .body(ApiResponse.created(response));
     }
 
-    // TODO: Auditing
     // 운영 지역 목록 조회 + 검색
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<AreaResponse>>> getAreas(
@@ -49,7 +50,6 @@ public class AreaController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: Auditing
     // 운영 지역 상세 조회
     @GetMapping("/{areaId}")
     public ResponseEntity<ApiResponse<AreaResponse>> getArea(@PathVariable UUID areaId) {
@@ -59,8 +59,8 @@ public class AreaController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: 권한 처리(MANAGER, MASTER), Auditing
     // 운영 지역 수정
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     @PutMapping("/{areaId}")
     public ResponseEntity<ApiResponse<AreaResponse>> updateArea(@PathVariable UUID areaId, @Valid @RequestBody AreaUpdateRequest request) {
 
@@ -69,12 +69,12 @@ public class AreaController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: 권한 처리(MASTER), Auditing (+ softDelete)
     // 운영 지역 삭제
+    @PreAuthorize("hasAnyRole('MASTER')")
     @DeleteMapping("/{areaId}")
-    public ResponseEntity<ApiResponse<Void>> deleteArea(@PathVariable UUID areaId) {
+    public ResponseEntity<ApiResponse<Void>> deleteArea(@PathVariable UUID areaId,@AuthenticationPrincipal UUID userId) {
 
-        areaService.deleteArea(areaId);
+        areaService.deleteArea(areaId,userId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
+++ b/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
@@ -130,9 +130,9 @@ public class CategoryService {
                 .build();
     }
 
-    // 카테고리 이름 기준 중복 조회 (존재 여부 확인)
+    // 카테고리 이름 중복 여부 확인 (삭제 안 된 것만 중복 체크)
     private void validateDuplicateCategory(String name) {
-        if (categoryRepository.existsByNameIgnoreCase(name)) {
+        if (categoryRepository.existsByNameIgnoreCaseAndDeletedAtIsNull(name)) {
             throw new BaseException(CategoryErrorCode.CATEGORY_ALREADY_EXISTS);
         }
     }

--- a/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
+++ b/src/main/java/com/sparta/todayeats/category/application/service/CategoryService.java
@@ -26,7 +26,6 @@ public class CategoryService {
     // 카테고리 생성
     @Transactional
     public CategoryCreateResponse createCategory(CategoryCreateRequest request) {
-
         // 입력값 정규화
         String name = normalizeName(request.getName());
 
@@ -59,7 +58,6 @@ public class CategoryService {
 
     // 카테고리 목록 조회 && 검색
     public PageResponse<CategoryResponse> getCategories(String keyword, Pageable pageable) {
-
         // keyword가 없으면 전체 조회, 있으면 이름 기준 검색
         Page<Category> result = findCategories(keyword, pageable);
 
@@ -83,7 +81,6 @@ public class CategoryService {
 
     // 카테고리 상세 조회
     public CategoryResponse getCategory(UUID categoryId) {
-
         // ID로 카테고리 조회 후 DTO 변환
         Category category = getCategoryEntity(categoryId);
         return toResponse(category);
@@ -93,7 +90,6 @@ public class CategoryService {
     // 카테고리 수정
     @Transactional
     public CategoryResponse updateCategory(UUID categoryId, CategoryUpdateRequest request) {
-
         // 수정 대상 카테고리 조회
         Category category = getCategoryEntity(categoryId);
 
@@ -114,12 +110,11 @@ public class CategoryService {
 
     // 카테고리 삭제
     @Transactional
-    public void deleteCategory(UUID categoryId) {
-
+    public void deleteCategory(UUID categoryId, UUID deletedBy) {
         Category category = getCategoryEntity(categoryId);
 
         // 소프트 삭제 처리
-        category.softDelete(null);
+        category.softDelete(deletedBy);
     }
 
 

--- a/src/main/java/com/sparta/todayeats/category/domain/entity/Category.java
+++ b/src/main/java/com/sparta/todayeats/category/domain/entity/Category.java
@@ -8,12 +8,15 @@ import org.hibernate.annotations.Where;
 import java.util.UUID;
 
 @Entity
-@Table( name = "p_category")
 @Getter
 @Builder
 @AllArgsConstructor
 @Where(clause = "deleted_at is null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "p_category",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deleted_at"})
+) // 삭제되지 않은 카테고리 이름 중복 방지
 public class Category extends BaseEntity {
 
     @Id
@@ -21,7 +24,7 @@ public class Category extends BaseEntity {
     @Column(name = "category_id")
     private UUID id;
 
-    @Column(nullable = false, length = 50, unique = true)
+    @Column(nullable = false, length = 50)
     private String name;
 
     public void updateName(String name) {

--- a/src/main/java/com/sparta/todayeats/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/todayeats/category/domain/repository/CategoryRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
     // 카테고리 이름 중복 여부 확인
-    boolean existsByNameIgnoreCase(String name);
+    boolean existsByNameIgnoreCaseAndDeletedAtIsNull(String name);
 
     // 카테고리 이름 기준 부분 일치(대소문자 무시) 검색 + 페이징 조회
     Page<Category> findByNameContainingIgnoreCase(String name, Pageable pageable);

--- a/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.sparta.todayeats.category.presentation.controller;
 
 import com.sparta.todayeats.category.application.service.CategoryService;
 import com.sparta.todayeats.category.presentation.dto.*;
+import com.sparta.todayeats.global.annotation.LoginUser;
 import com.sparta.todayeats.global.response.ApiResponse;
 import com.sparta.todayeats.global.response.PageResponse;
 import jakarta.validation.Valid;
@@ -69,7 +70,7 @@ public class CategoryController {
     // 카테고리 삭제
     @DeleteMapping("/{categoryId}")
     @PreAuthorize("hasAnyRole('MASTER')")
-    public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable UUID categoryId,@AuthenticationPrincipal UUID userId) {
+    public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable UUID categoryId,@LoginUser UUID userId) {
 
         categoryService.deleteCategory(categoryId,userId);
 

--- a/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -22,9 +23,10 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    // TODO: 권한 처리, Auditing
+    // TODO: Auditing
     // 카테고리 생성
     @PostMapping
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     public ResponseEntity<ApiResponse<CategoryCreateResponse>> createCategory(@Valid @RequestBody CategoryCreateRequest request) {
         CategoryCreateResponse response = categoryService.createCategory(request);
 
@@ -56,9 +58,10 @@ public class CategoryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: 권한 처리, Auditing
+    // TODO: Auditing
     // 카테고리 수정
     @PutMapping("/{categoryId}")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     public ResponseEntity<ApiResponse<CategoryResponse>> updateCategory(@PathVariable UUID categoryId, @Valid @RequestBody CategoryUpdateRequest request) {
 
         CategoryResponse response = categoryService.updateCategory(categoryId, request);
@@ -66,9 +69,10 @@ public class CategoryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: 권한 처리, Auditing (+ softDelete)
+    // TODO: Auditing (+ softDelete)
     // 카테고리 삭제
     @DeleteMapping("/{categoryId}")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable UUID categoryId) {
 
         categoryService.deleteCategory(categoryId);

--- a/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/sparta/todayeats/category/presentation/controller/CategoryController.java
@@ -12,6 +12,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -23,7 +24,6 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    // TODO: Auditing
     // 카테고리 생성
     @PostMapping
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
@@ -35,7 +35,6 @@ public class CategoryController {
                 .body(ApiResponse.created(response));
     }
 
-    // TODO: Auditing
     // 카테고리 목록 조회 + 검색
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<CategoryResponse>>> getCategories(
@@ -48,7 +47,6 @@ public class CategoryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: Auditing
     // 카테고리 상세 조회
     @GetMapping("/{categoryId}")
     public ResponseEntity<ApiResponse<CategoryResponse>> getCategory(@PathVariable UUID categoryId) {
@@ -58,7 +56,6 @@ public class CategoryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: Auditing
     // 카테고리 수정
     @PutMapping("/{categoryId}")
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
@@ -69,13 +66,12 @@ public class CategoryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: Auditing (+ softDelete)
     // 카테고리 삭제
     @DeleteMapping("/{categoryId}")
-    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
-    public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable UUID categoryId) {
+    @PreAuthorize("hasAnyRole('MASTER')")
+    public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable UUID categoryId,@AuthenticationPrincipal UUID userId) {
 
-        categoryService.deleteCategory(categoryId);
+        categoryService.deleteCategory(categoryId,userId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/sparta/todayeats/global/exception/AreaErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/AreaErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum AreaErrorCode implements ErrorCode {
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "AREA-001", "지역을 찾을 수 없습니다."),
     AREA_ALREADY_EXISTS(HttpStatus.CONFLICT, "AREA-002", "이미 존재하는 지역입니다."),
-    INVALID_AREA_NAME(HttpStatus.BAD_REQUEST, "AREA-003", "유효하지 않은 지역 이름입니다.");
+    INVALID_AREA_NAME(HttpStatus.BAD_REQUEST, "AREA-003", "유효하지 않은 지역 이름입니다."),
+    AREA_INACTIVE(HttpStatus.BAD_REQUEST, "AREA-004", "비활성화된 지역입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/CommonErrorCode.java
@@ -11,8 +11,8 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-002", "잘못된 요청입니다."),
     INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "COMMON-003", "페이지 사이즈는 10, 30, 50만 가능합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON-004", "접근 권한이 없습니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-405", "지원하지 않는 HTTP 메서드입니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-404", "요청한 경로를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-005", "지원하지 않는 HTTP 메서드입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-006", "요청한 경로를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-999", "서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/sparta/todayeats/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/CommonErrorCode.java
@@ -11,6 +11,8 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-002", "잘못된 요청입니다."),
     INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "COMMON-003", "페이지 사이즈는 10, 30, 50만 가능합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON-004", "접근 권한이 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-405", "지원하지 않는 HTTP 메서드입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-404", "요청한 경로를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-999", "서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/sparta/todayeats/global/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/StoreErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum StoreErrorCode implements ErrorCode {
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE-001", "가게를 찾을 수 없습니다."),
     STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "STORE-002", "이미 존재하는 가게 이름입니다"),
-    STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORE-003", "가게 수정 권한이 없습니다");;
+    STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORE-003", "해당 가게에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/global/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/StoreErrorCode.java
@@ -10,7 +10,8 @@ public enum StoreErrorCode implements ErrorCode {
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE-001", "가게를 찾을 수 없습니다."),
     STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "STORE-002", "이미 존재하는 가게 이름입니다"),
     STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORE-003", "해당 가게에 대한 접근 권한이 없습니다."),
-    INVALID_STORE_NAME(HttpStatus.BAD_REQUEST, "STORE-004", "유효하지 않은 가게 이름입니다.");
+    INVALID_STORE_NAME(HttpStatus.BAD_REQUEST, "STORE-004", "유효하지 않은 가게 이름입니다."),
+    STORE_NOT_VISIBLE(HttpStatus.FORBIDDEN, "STORE-005", "숨김 처리된 가게는 조회할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/global/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/StoreErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum StoreErrorCode implements ErrorCode {
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE-001", "가게를 찾을 수 없습니다."),
     STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "STORE-002", "이미 존재하는 가게 이름입니다"),
-    STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORE-003", "해당 가게에 대한 접근 권한이 없습니다.");
+    STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORE-003", "해당 가게에 대한 접근 권한이 없습니다."),
+    INVALID_STORE_NAME(HttpStatus.BAD_REQUEST, "STORE-004", "유효하지 않은 가게 이름입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/config/JpaConfig.java
@@ -1,9 +1,26 @@
 package com.sparta.todayeats.global.infrastructure.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+    // 현재 로그인한 사용자의 UUID를 Auditing에 제공
+    @Bean
+    public AuditorAware<UUID> auditorAware() {
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .filter(Authentication::isAuthenticated)        // 인증된 사용자인지 확인
+                .filter(auth -> !auth.getName().equals("anonymousUser"))  // 비로그인 제외
+                .map(Authentication::getName)
+                .map(UUID::fromString);                         // String → UUID 변환
+    }
 }

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
@@ -6,10 +6,12 @@ import com.sparta.todayeats.global.exception.CommonErrorCode;
 import com.sparta.todayeats.global.exception.ErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.validation.FieldError;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -26,6 +28,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AuthorizationDeniedException.class)
     public ResponseEntity<?> handleAccessDeniedException(AuthorizationDeniedException e) {
         return buildResponse(AuthErrorCode.FORBIDDEN);
+    }
+
+    // 지원하지 않는 HTTP 메서드 요청 (405)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<?> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        return buildResponse(CommonErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    // 경로를 찾을 수 없음 (404)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<?> handleNoResourceFound(NoResourceFoundException e) {
+        return buildResponse(CommonErrorCode.NOT_FOUND);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/sparta/todayeats/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/todayeats/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.sparta.todayeats.global.infrastructure.presentation.advice;
 
+import com.sparta.todayeats.global.exception.AuthErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.exception.CommonErrorCode;
 import com.sparta.todayeats.global.exception.ErrorCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -20,8 +22,15 @@ public class GlobalExceptionHandler {
         return buildResponse(e.getErrorCode());
     }
 
+    // 접근 권한 없음 (403)
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<?> handleAccessDeniedException(AuthorizationDeniedException e) {
+        return buildResponse(AuthErrorCode.FORBIDDEN);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception e) {
+        e.printStackTrace();
         return buildResponse(CommonErrorCode.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
+++ b/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
@@ -17,7 +17,7 @@ public class DataInitializer implements ApplicationRunner {
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
-        if (areaRepository.existsByNameIgnoreCase("광화문")) return; // 이미 있으면 스킵
+        if (areaRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("광화문")) return; // 이미 있으면 스킵
 
         areaRepository.save(Area.builder()
                 .name("광화문")

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -56,7 +56,7 @@ public class StoreController {
     }
 
     // 가게 단건 조회
-    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER: 본인거+공게 / MANAGER,MASTER: 전체
+    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER: 본인거+공게 / MANAGER,MASTER: 전체 노출
     @GetMapping("/{storeId}")
     public ResponseEntity<ApiResponse<StoreResponse>> getStore(
             @PathVariable UUID storeId,

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -78,12 +78,13 @@ public class StoreController {
     }
 
     // 가게 삭제
+    // OWNER는 본인 가게만 삭제 가능/ MASTER는 모든 가게 삭제 가능
     @DeleteMapping("/{storeId}")
     @PreAuthorize("hasAnyRole('OWNER','MASTER')")
     public ResponseEntity<ApiResponse<Void>> deleteStore(
-            @PathVariable UUID storeId,@AuthenticationPrincipal UUID userId) {
+            @PathVariable UUID storeId,@AuthenticationPrincipal UUID userId, Authentication authentication) {
 
-        storeService.deleteStore(storeId, userId);
+        storeService.deleteStore(storeId, userId, authentication);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -65,13 +65,14 @@ public class StoreController {
     }
 
     // 가게 수정
+    // OWNER는 본인 가게만 수정 가능/ MANAGER, MASTER는 모든 가게 수정 가능
     @PatchMapping("/{storeId}")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ApiResponse<StoreResponse>> updateStore(
             @PathVariable UUID storeId,
-            @Valid @RequestBody StoreUpdateRequest request,@AuthenticationPrincipal UUID userId) {
+            @Valid @RequestBody StoreUpdateRequest request,@AuthenticationPrincipal UUID userId, Authentication authentication) {
 
-        StoreResponse response = storeService.updateStore(storeId, request,userId);
+        StoreResponse response = storeService.updateStore(storeId, request,userId,authentication);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 public class StoreController {
 
     private final StoreService storeService;
-
+    
     // 가게 생성
     @PostMapping
     @PreAuthorize("hasAnyRole('OWNER')")

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -27,11 +29,10 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    // TODO: 권한 처리(OWNER), Auditing
-    // TODO: 인증 구현 후 토큰에서 꺼내기 -> userId
     // 가게 생성
     @PostMapping
-    public ResponseEntity<ApiResponse<StoreCreateResponse>> createStore(@Valid @RequestBody StoreCreateRequest request, @RequestHeader("X-User-Id") UUID userId) {
+    @PreAuthorize("hasAnyRole('OWNER')")
+    public ResponseEntity<ApiResponse<StoreCreateResponse>> createStore(@Valid @RequestBody StoreCreateRequest request,@AuthenticationPrincipal UUID userId) {
         StoreCreateResponse response = storeService.createStore(request, userId);
 
         return ResponseEntity
@@ -39,7 +40,6 @@ public class StoreController {
                 .body(ApiResponse.created(response));
     }
 
-    // TODO: Auditing
     // TODO: CUSTOMER → isHidden = false 인 것만 노출
     // TODO: OWNER/MANAGER/MASTER → 숨김 포함 전체 노출
     // 가게 목록 조회 + 복합 검색 (카테고리, 이름)
@@ -52,8 +52,7 @@ public class StoreController {
         PageResponse<StoreResponse> response = storeService.getStores(categoryName, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
-
-    // TODO: Auditing
+    
     // 가게 단건 조회
     @GetMapping("/{storeId}")
     public ResponseEntity<ApiResponse<StoreResponse>> getStore(
@@ -64,42 +63,35 @@ public class StoreController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: 권한 처리(OWNER, MANAGER, MASTER), Auditing
-    // TODO: 인증 구현 후 토큰에서 꺼내기 -> userId
     // 가게 수정
     @PatchMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ApiResponse<StoreResponse>> updateStore(
             @PathVariable UUID storeId,
-            @Valid @RequestBody StoreUpdateRequest request,
-            @RequestHeader("X-User-Id") UUID userId) {
+            @Valid @RequestBody StoreUpdateRequest request,@AuthenticationPrincipal UUID userId) {
 
         StoreResponse response = storeService.updateStore(storeId, request,userId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: 권한 처리(OWNER, MASTER), Auditing
-    // TODO: 인증 구현 후 토큰에서 꺼내기 -> userId
     // 가게 삭제
     @DeleteMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER','MASTER')")
     public ResponseEntity<ApiResponse<Void>> deleteStore(
-            @PathVariable UUID storeId,
-            @RequestHeader("X-User-Id") UUID userId) {
+            @PathVariable UUID storeId,@AuthenticationPrincipal UUID userId) {
 
         storeService.deleteStore(storeId, userId);
 
         return ResponseEntity.noContent().build();
     }
 
-
-    // TODO: 권한 처리(OWNER, MANAGER, MASTER), Auditing
-    // TODO: 인증 구현 후 토큰에서 꺼내기 -> userId
     // 가게 숨김 처리
     @PatchMapping("/{storeId}/hide")
+    @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ApiResponse<StoreHiddenResponse>> updateHidden(
             @PathVariable UUID storeId,
-            @Valid @RequestBody StoreHiddenRequest request,
-            @RequestHeader("X-User-Id") UUID userId) {
+            @Valid @RequestBody StoreHiddenRequest request,@AuthenticationPrincipal UUID userId) {
 
         StoreHiddenResponse response = storeService.updateHidden(storeId, request, userId);
 

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -42,7 +42,7 @@ public class StoreController {
     }
 
     // 가게 목록 조회 + 복합 검색 (카테고리, 이름)
-    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER: 자기것만 / MANAGER,MASTER: 전체 노출
+    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER: 본인거+공개 / MANAGER,MASTER: 전체 노출
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<StoreResponse>>> getStores(
             @RequestParam(required = false) String categoryName,
@@ -56,11 +56,14 @@ public class StoreController {
     }
 
     // 가게 단건 조회
+    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER: 본인거+공게 / MANAGER,MASTER: 전체
     @GetMapping("/{storeId}")
     public ResponseEntity<ApiResponse<StoreResponse>> getStore(
-            @PathVariable UUID storeId) {
+            @PathVariable UUID storeId,
+            @AuthenticationPrincipal UUID userId,
+            Authentication authentication) {
 
-        StoreResponse response = storeService.getStore(storeId);
+        StoreResponse response = storeService.getStore(storeId, userId, authentication);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.sparta.todayeats.store.controller;
 
+import com.sparta.todayeats.global.annotation.LoginUser;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.response.ApiResponse;
 import com.sparta.todayeats.store.dto.request.StoreCreateRequest;
@@ -33,7 +34,7 @@ public class StoreController {
     // 가게 생성
     @PostMapping
     @PreAuthorize("hasAnyRole('OWNER')")
-    public ResponseEntity<ApiResponse<StoreCreateResponse>> createStore(@Valid @RequestBody StoreCreateRequest request,@AuthenticationPrincipal UUID userId) {
+    public ResponseEntity<ApiResponse<StoreCreateResponse>> createStore(@Valid @RequestBody StoreCreateRequest request,@LoginUser UUID userId) {
         StoreCreateResponse response = storeService.createStore(request, userId);
 
         return ResponseEntity
@@ -50,7 +51,7 @@ public class StoreController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable,
             Authentication authentication,
-            @AuthenticationPrincipal UUID userId) {
+            @LoginUser UUID userId) {
         PageResponse<StoreResponse> response = storeService.getStores(categoryName, keyword, pageable, authentication, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -60,7 +61,7 @@ public class StoreController {
     @GetMapping("/{storeId}")
     public ResponseEntity<ApiResponse<StoreResponse>> getStore(
             @PathVariable UUID storeId,
-            @AuthenticationPrincipal UUID userId,
+            @LoginUser UUID userId,
             Authentication authentication) {
 
         StoreResponse response = storeService.getStore(storeId, userId, authentication);
@@ -74,7 +75,7 @@ public class StoreController {
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ApiResponse<StoreResponse>> updateStore(
             @PathVariable UUID storeId,
-            @Valid @RequestBody StoreUpdateRequest request,@AuthenticationPrincipal UUID userId, Authentication authentication) {
+            @Valid @RequestBody StoreUpdateRequest request,@LoginUser UUID userId, Authentication authentication) {
 
         StoreResponse response = storeService.updateStore(storeId, request,userId,authentication);
 
@@ -86,7 +87,7 @@ public class StoreController {
     @DeleteMapping("/{storeId}")
     @PreAuthorize("hasAnyRole('OWNER','MASTER')")
     public ResponseEntity<ApiResponse<Void>> deleteStore(
-            @PathVariable UUID storeId,@AuthenticationPrincipal UUID userId, Authentication authentication) {
+            @PathVariable UUID storeId,@LoginUser UUID userId, Authentication authentication) {
 
         storeService.deleteStore(storeId, userId, authentication);
 
@@ -99,7 +100,7 @@ public class StoreController {
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ApiResponse<StoreHiddenResponse>> updateHidden(
             @PathVariable UUID storeId,
-            @Valid @RequestBody StoreHiddenRequest request,@AuthenticationPrincipal UUID userId,  Authentication authentication) {
+            @Valid @RequestBody StoreHiddenRequest request, @LoginUser UUID userId, Authentication authentication) {
 
         StoreHiddenResponse response = storeService.updateHidden(storeId, request, userId, authentication);
 

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 public class StoreController {
 
     private final StoreService storeService;
-    
+
     // 가게 생성
     @PostMapping
     @PreAuthorize("hasAnyRole('OWNER')")
@@ -42,15 +42,16 @@ public class StoreController {
     }
 
     // 가게 목록 조회 + 복합 검색 (카테고리, 이름)
-    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER,MANAGER,MASTER: 숨김 포함 전체 노출
+    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER: 자기것만 / MANAGER,MASTER: 전체 노출
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<StoreResponse>>> getStores(
             @RequestParam(required = false) String categoryName,
             @RequestParam(required = false) String keyword,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable,
-            Authentication authentication) {
-        PageResponse<StoreResponse> response = storeService.getStores(categoryName, keyword, pageable, authentication);
+            Authentication authentication,
+            @AuthenticationPrincipal UUID userId) {
+        PageResponse<StoreResponse> response = storeService.getStores(categoryName, keyword, pageable, authentication, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -17,6 +17,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,19 +41,19 @@ public class StoreController {
                 .body(ApiResponse.created(response));
     }
 
-    // TODO: CUSTOMER → isHidden = false 인 것만 노출
-    // TODO: OWNER/MANAGER/MASTER → 숨김 포함 전체 노출
     // 가게 목록 조회 + 복합 검색 (카테고리, 이름)
+    // CUSTOMER,비로그인: 공개 가게만 노출 / OWNER,MANAGER,MASTER: 숨김 포함 전체 노출
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<StoreResponse>>> getStores(
             @RequestParam(required = false) String categoryName,
             @RequestParam(required = false) String keyword,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable) {
-        PageResponse<StoreResponse> response = storeService.getStores(categoryName, keyword, pageable);
+            Pageable pageable,
+            Authentication authentication) {
+        PageResponse<StoreResponse> response = storeService.getStores(categoryName, keyword, pageable, authentication);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
-    
+
     // 가게 단건 조회
     @GetMapping("/{storeId}")
     public ResponseEntity<ApiResponse<StoreResponse>> getStore(

--- a/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/todayeats/store/controller/StoreController.java
@@ -90,13 +90,14 @@ public class StoreController {
     }
 
     // 가게 숨김 처리
+    // OWNER는 본인 가게만 가능/ MANAGER, MASTER는 모든 가게 숨김 처리 가능
     @PatchMapping("/{storeId}/hide")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ApiResponse<StoreHiddenResponse>> updateHidden(
             @PathVariable UUID storeId,
-            @Valid @RequestBody StoreHiddenRequest request,@AuthenticationPrincipal UUID userId) {
+            @Valid @RequestBody StoreHiddenRequest request,@AuthenticationPrincipal UUID userId,  Authentication authentication) {
 
-        StoreHiddenResponse response = storeService.updateHidden(storeId, request, userId);
+        StoreHiddenResponse response = storeService.updateHidden(storeId, request, userId, authentication);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/sparta/todayeats/store/entity/Store.java
+++ b/src/main/java/com/sparta/todayeats/store/entity/Store.java
@@ -12,12 +12,15 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_store")
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "deleted_at is null")
+@Table(
+        name = "p_store",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deleted_at"})
+)
 public class Store extends BaseEntity {
 
     @Id

--- a/src/main/java/com/sparta/todayeats/store/entity/Store.java
+++ b/src/main/java/com/sparta/todayeats/store/entity/Store.java
@@ -63,9 +63,7 @@ public class Store extends BaseEntity {
     public void update(String name, String address, String phone) {
         this.name = name;
         this.address = address;
-        if (phone != null) {
-            this.phone = phone.isBlank() ? null : phone;
-        }
+        this.phone = phone;
     }
 
     public void updateAverageRating(BigDecimal averageRating) {

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public interface StoreRepository extends JpaRepository<Store, UUID>, StoreRepositoryCustom {
 
     // 이름 중복 확인
-    boolean existsByNameIgnoreCase(String name);
+    boolean existsByNameIgnoreCaseAndDeletedAtIsNull(String name);
 
     // store 조회 시 owner도 한번에 가져오기
     @Query("SELECT s FROM Store s JOIN FETCH s.owner WHERE s.id = :storeId")

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryCustom.java
@@ -3,10 +3,13 @@ package com.sparta.todayeats.store.repository;
 import com.sparta.todayeats.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+
+import java.util.UUID;
 
 
 // QueryDSL로 구현할 커스텀 쿼리 메서드 정의
 // StoreRepository가 이 인터페이스를 상속받아서 사용
 public interface StoreRepositoryCustom {
-    Page<Store> searchStores(String categoryName, String keyword, Pageable pageable, boolean isCustomer);
+    Page<Store> searchStores(String categoryName, String keyword, Pageable pageable, Authentication authentication, UUID userId);
 }

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryCustom.java
@@ -8,5 +8,5 @@ import org.springframework.data.domain.Pageable;
 // QueryDSL로 구현할 커스텀 쿼리 메서드 정의
 // StoreRepository가 이 인터페이스를 상속받아서 사용
 public interface StoreRepositoryCustom {
-    Page<Store> searchStores(String categoryName, String keyword, Pageable pageable);
+    Page<Store> searchStores(String categoryName, String keyword, Pageable pageable, boolean isCustomer);
 }

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryImpl.java
@@ -75,6 +75,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                 .where(builder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .orderBy(store.createdAt.desc())
                 .fetch();
 
         long total = queryFactory

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryImpl.java
@@ -21,7 +21,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Store> searchStores(String categoryName, String keyword, Pageable pageable) {
+    public Page<Store> searchStores(String categoryName, String keyword, Pageable pageable, boolean isCustomer) {
 
         // compileJava로 자동 생성된 Q클래스 (Store 엔티티 기반)
         // 타입 안전하게 컬럼명, 조건 등을 작성할 수 있게 해줌
@@ -29,6 +29,12 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
 
         // 동적 조건을 조합하는 빌더 (AND)
         BooleanBuilder builder = new BooleanBuilder();
+
+        // CUSTOMER or 비로그인 → 공개된 가게만 노출
+        // OWNER / MANAGER / MASTER → 숨긴 가게 포함 전체 노출
+        if (isCustomer) {
+            builder.and(store.isHidden.isFalse());
+        }
 
         // 카테고리 이름으로 필터
         if (categoryName != null && !categoryName.isBlank()) {
@@ -39,11 +45,6 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
         if (keyword != null && !keyword.isBlank()) {
             builder.and(store.name.containsIgnoreCase(keyword));
         }
-
-        // 숨김 처리된 가게 제외
-        // TODO: 권한 구현 후 OWNER, MASTER, MANAGER는 isHidden 조건 제거
-        // 숨김 처리된 가게 제외 (CUSTOMER만 적용)
-        builder.and(store.isHidden.isFalse());
 
         // 실제 데이터 조회 (페이징 적용)
         List<Store> content = queryFactory

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepositoryImpl.java
@@ -9,8 +9,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.security.core.Authentication;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,20 +23,12 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Store> searchStores(String categoryName, String keyword, Pageable pageable, boolean isCustomer) {
+    public Page<Store> searchStores(String categoryName, String keyword, Pageable pageable, Authentication authentication, UUID userId) {
 
-        // compileJava로 자동 생성된 Q클래스 (Store 엔티티 기반)
-        // 타입 안전하게 컬럼명, 조건 등을 작성할 수 있게 해줌
+        // Q클래스, 빌더 (동적 조건 조합)
         QStore store = QStore.store;
-
-        // 동적 조건을 조합하는 빌더 (AND)
         BooleanBuilder builder = new BooleanBuilder();
 
-        // CUSTOMER or 비로그인 → 공개된 가게만 노출
-        // OWNER / MANAGER / MASTER → 숨긴 가게 포함 전체 노출
-        if (isCustomer) {
-            builder.and(store.isHidden.isFalse());
-        }
 
         // 카테고리 이름으로 필터
         if (categoryName != null && !categoryName.isBlank()) {
@@ -46,23 +40,50 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
             builder.and(store.name.containsIgnoreCase(keyword));
         }
 
+        // 권한 확인
+        boolean isAnonymous = authentication == null;
+
+        boolean isCustomer = authentication != null &&
+                authentication.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_CUSTOMER"));
+
+        boolean isOwner = authentication != null &&
+                authentication.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_OWNER"));
+
+        boolean isManagerOrMaster = authentication != null &&
+                authentication.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_MANAGER")
+                                || a.getAuthority().equals("ROLE_MASTER"));
+
+        // 비로그인 / CUSTOMER → 공개만
+        if (isAnonymous || isCustomer) {
+            builder.and(store.isHidden.isFalse());
+        }
+
+        // OWNER → 공개 + 내 가게
+        else if (isOwner) {
+            builder.and(
+                    store.isHidden.isFalse()
+                            .or(store.owner.userId.eq(userId))
+            );
+        }
+
         // 실제 데이터 조회 (페이징 적용)
         List<Store> content = queryFactory
-                .selectFrom(store)      // SELECT * FROM p_store
-                .where(builder)         // WHERE 동적 조건
-                .offset(pageable.getOffset())       // 시작 위치 (page * size)
-                .limit(pageable.getPageSize())       // 가져올 개수
-                .orderBy(store.createdAt.desc())     // 최신순 정렬
+                .selectFrom(store)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
-        // 전체 데이터 개수 조회 (totalPages 계산에 필요)
-        Long total = queryFactory
+        long total = queryFactory
                 .select(store.count())
                 .from(store)
                 .where(builder)
                 .fetchOne();
 
         // Page 객체로 감싸서 반환
-        return new PageImpl<>(content, pageable, total != null ? total : 0);
+        return new PageImpl<>(content, pageable, total);
     }
 }

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -133,14 +133,18 @@ public class StoreService {
 
     // 가게 삭제
     @Transactional
-    public void deleteStore(UUID storeId, UUID userId) {
+    public void deleteStore(UUID storeId, UUID userId, Authentication authentication) {
 
         // 삭제 대상 가게 조회
         Store store = getStoreEntity(storeId);
 
-        // TODO: 인증 구현 후 MASTER는 본인 가게 아니어도 삭제 가능하도록 분기
-        // 본인 가게인지 확인
-        validateStoreOwner(store, userId);
+        // MASTER는 모든 가게 삭제 가능 / OWNER는 본인 가게만 삭제 가능
+        boolean isMaster = authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_MASTER"));
+
+        if (!isMaster) {
+            validateStoreOwner(store, userId);
+        }
 
         // 소프트 삭제
         store.softDelete(userId);

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -153,14 +153,18 @@ public class StoreService {
 
     // 가게 숨김 처리
     @Transactional
-    public StoreHiddenResponse updateHidden(UUID storeId, StoreHiddenRequest request, UUID userId) {
+    public StoreHiddenResponse updateHidden(UUID storeId, StoreHiddenRequest request, UUID userId,  Authentication authentication) {
 
         // 숨김 처리 대상 가게 조회
         Store store = getStoreEntity(storeId);
 
-        // TODO: 인증 구현 후 MANAGER, MASTER는 본인 가게 아니어도 숨김 처리 가능하도록 분기
-        // 본인 가게인지 확인
-        validateStoreOwner(store, userId);
+        // MANAGER, MASTER는 모든 가게 숨김 처리 가능 / OWNER는 본인 가게만 가능
+        boolean isManagerOrMaster = authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_MANAGER") || a.getAuthority().equals("ROLE_MASTER"));
+
+        if (!isManagerOrMaster) {
+            validateStoreOwner(store, userId);
+        }
 
         // 숨김 처리
         if (request.getIsHidden()) {

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -72,14 +72,9 @@ public class StoreService {
 
 
     // 가게 목록 조회 && 검색 (카테고리 + 이름 복합 필터)
-    public PageResponse<StoreResponse> getStores(String categoryName, String keyword, Pageable pageable, Authentication authentication) {
-        // 비로그인 or CUSTOMER면 공개된 가게만 노출, 나머지는 전체 노출
-        boolean isCustomer = authentication == null
-                || authentication.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_CUSTOMER"));
-
-        // QueryDSL 동적 쿼리로 조회
-        Page<Store> result = storeRepository.searchStores(categoryName, keyword, pageable,isCustomer);
+    public PageResponse<StoreResponse> getStores(String categoryName, String keyword, Pageable pageable, Authentication authentication, UUID userId) {
+        // QueryDSL 동적 쿼리로 조회 (+ 권한)
+        Page<Store> result = storeRepository.searchStores(categoryName, keyword, pageable,authentication,userId);
 
         // 엔티티 → DTO 변환
         List<StoreResponse> content = result.getContent()

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -42,15 +42,17 @@ public class StoreService {
     // 가게 생성
     @Transactional
     public StoreCreateResponse createStore(StoreCreateRequest request, UUID userId) {
+        // 운영 지역 조회
+        Area area = getAreaEntity(request.getAreaId());
+
+        // 운영 지역 활성화 여부 확인
+        validateAreaActive(area);
 
         // 가게 이름 중복 검증
         validateDuplicateStore(request.getName());
 
         // 소유자 조회
         User owner = getUserEntity(userId);
-
-        // 운영 지역 조회
-        Area area = getAreaEntity(request.getAreaId());
 
         // 카테고리 조회
         Category category = getCategoryEntity(request.getCategoryId());
@@ -200,6 +202,13 @@ public class StoreService {
     private Category getCategoryEntity(UUID categoryId) {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new BaseException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    // 운영 지역 활성화 여부 확인
+    private void validateAreaActive(Area area) {
+        if (!area.getIsActive()) {
+            throw new BaseException(AreaErrorCode.AREA_INACTIVE);
+        }
     }
 
     // 가게  이름 중복 여부 확인 (삭제 안 된 것만 중복 체크)

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -42,19 +42,16 @@ public class StoreService {
     // 가게 생성
     @Transactional
     public StoreCreateResponse createStore(StoreCreateRequest request, UUID userId) {
-        // 운영 지역 조회
+        // 운영 지역 조회, 활성화 여부 확인
         Area area = getAreaEntity(request.getAreaId());
-
-        // 운영 지역 활성화 여부 확인
         validateAreaActive(area);
 
-        // 가게 이름 중복 검증
-        validateDuplicateStore(request.getName());
+        // 가게 이름 정규화, 중복 검증
+        String name = normalizeStoreName(request.getName());
+        validateDuplicateStore(name);
 
-        // 소유자 조회
+        // 소유자, 카테고리 조회
         User owner = getUserEntity(userId);
-
-        // 카테고리 조회
         Category category = getCategoryEntity(request.getCategoryId());
 
         // 가게 엔티티 생성
@@ -62,9 +59,9 @@ public class StoreService {
                 .owner(owner)
                 .area(area)
                 .category(category)
-                .name(request.getName())
+                .name(name)
                 .address(request.getAddress())
-                .phone(request.getPhone())
+                .phone(normalizePhone(request.getPhone()))
                 .build();
 
         // DB 저장
@@ -120,14 +117,18 @@ public class StoreService {
         boolean isManagerOrMaster = authentication.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_MANAGER") || a.getAuthority().equals("ROLE_MASTER"));
 
-        System.out.println("isManagerOrMaster: " + isManagerOrMaster);
-
         if (!isManagerOrMaster) {
             validateStoreOwner(store, userId);
         }
 
+        // 정규화, 이름 중복 체크
+        String name = normalizeStoreName(request.getName());
+        if (!store.getName().equalsIgnoreCase(name)) {
+            validateDuplicateStore(name);
+        }
+
         // 전체 교체
-        store.update(request.getName(), request.getAddress(), request.getPhone());
+        store.update(name, request.getAddress(), normalizePhone(request.getPhone()));
 
         return toResponse(store);
     }
@@ -136,7 +137,6 @@ public class StoreService {
     // 가게 삭제
     @Transactional
     public void deleteStore(UUID storeId, UUID userId, Authentication authentication) {
-
         // 삭제 대상 가게 조회
         Store store = getStoreEntity(storeId);
 
@@ -156,7 +156,6 @@ public class StoreService {
     // 가게 숨김 처리
     @Transactional
     public StoreHiddenResponse updateHidden(UUID storeId, StoreHiddenRequest request, UUID userId,  Authentication authentication) {
-
         // 숨김 처리 대상 가게 조회
         Store store = getStoreEntity(storeId);
 
@@ -223,6 +222,28 @@ public class StoreService {
         if (!store.getOwner().getUserId().equals(userId)) {
             throw new BaseException(StoreErrorCode.STORE_FORBIDDEN);
         }
+    }
+
+    // 가게 이름 정규화
+    private String normalizeStoreName(String name) {
+        if (name == null) {
+            throw new BaseException(StoreErrorCode.INVALID_STORE_NAME);
+        }
+        String normalized = name.trim();
+
+        if (normalized.isBlank()) {
+            throw new BaseException(StoreErrorCode.INVALID_STORE_NAME);
+        }
+
+        return normalized;
+    }
+
+    // 핸드폰 번호 정규화
+    private String normalizePhone(String phone) {
+        if (phone == null || phone.isBlank()) {
+            return null;
+        }
+        return phone.trim();
     }
 
     // Store 엔티티 → 생성 응답 DTO 변환

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -72,10 +73,14 @@ public class StoreService {
 
 
     // 가게 목록 조회 && 검색 (카테고리 + 이름 복합 필터)
-    public PageResponse<StoreResponse> getStores(String categoryName, String keyword, Pageable pageable) {
+    public PageResponse<StoreResponse> getStores(String categoryName, String keyword, Pageable pageable, Authentication authentication) {
+        // 비로그인 or CUSTOMER면 공개된 가게만 노출, 나머지는 전체 노출
+        boolean isCustomer = authentication == null
+                || authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_CUSTOMER"));
 
         // QueryDSL 동적 쿼리로 조회
-        Page<Store> result = storeRepository.searchStores(categoryName, keyword, pageable);
+        Page<Store> result = storeRepository.searchStores(categoryName, keyword, pageable,isCustomer);
 
         // 엔티티 → DTO 변환
         List<StoreResponse> content = result.getContent()

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -202,9 +202,9 @@ public class StoreService {
                 .orElseThrow(() -> new BaseException(CategoryErrorCode.CATEGORY_NOT_FOUND));
     }
 
-    // 가게 이름 중복 검증
+    // 가게  이름 중복 여부 확인 (삭제 안 된 것만 중복 체크)
     private void validateDuplicateStore(String name) {
-        if (storeRepository.existsByNameIgnoreCase(name)) {
+        if (storeRepository.existsByNameIgnoreCaseAndDeletedAtIsNull(name)) {
             throw new BaseException(StoreErrorCode.STORE_ALREADY_EXISTS);
         }
     }

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -95,9 +95,20 @@ public class StoreService {
 
 
     // 가게 단건 조회
-    public StoreResponse getStore(UUID storeId) {
+    public StoreResponse getStore(UUID storeId, UUID userId, Authentication authentication) {
         // 가게 엔티티 조회
         Store store = getStoreEntity(storeId);
+
+        // 숨김 아니면 누구나 조회 가능
+        if (!store.getIsHidden()) {
+            return toResponse(store);
+        }
+
+        // 숨김이면 권한 체크
+        if (!canAccessHiddenStore(store, userId, authentication)) {
+            throw new BaseException(StoreErrorCode.STORE_NOT_VISIBLE);
+        }
+
         return toResponse(store);
     }
 
@@ -239,6 +250,24 @@ public class StoreService {
             return null;
         }
         return phone.trim();
+    }
+
+    // 권한 체크
+    private boolean canAccessHiddenStore(Store store, UUID userId, Authentication authentication) {
+
+        boolean isManagerOrMaster = authentication != null &&
+                authentication.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_MANAGER")
+                                || a.getAuthority().equals("ROLE_MASTER"));
+
+        boolean isOwner = authentication != null &&
+                authentication.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_OWNER"));
+
+        boolean isMyStore = userId != null &&
+                store.getOwner().getUserId().equals(userId);
+
+        return isManagerOrMaster || (isOwner && isMyStore);
     }
 
     // Store 엔티티 → 생성 응답 DTO 변환

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -110,13 +110,19 @@ public class StoreService {
 
     // 가게 수정
     @Transactional
-    public StoreResponse updateStore(UUID storeId, StoreUpdateRequest request, UUID userId) {
+    public StoreResponse updateStore(UUID storeId, StoreUpdateRequest request, UUID userId,Authentication authentication) {
         // 수정 대상 가게 조회
         Store store = getStoreEntity(storeId);
 
-        // TODO: 인증 구현 후 MANAGER, MASTER는 본인 가게 아니어도 수정 가능하도록 분기
-        // 본인 가게인지 확인
-        validateStoreOwner(store, userId);
+        // MANAGER, MASTER는 모든 가게 수정 가능 / OWNER는 본인 가게만 수정 가능
+        boolean isManagerOrMaster = authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_MANAGER") || a.getAuthority().equals("ROLE_MASTER"));
+
+        System.out.println("isManagerOrMaster: " + isManagerOrMaster);
+
+        if (!isManagerOrMaster) {
+            validateStoreOwner(store, userId);
+        }
 
         // 전체 교체
         store.update(request.getName(), request.getAddress(), request.getPhone());

--- a/src/test/java/com/sparta/todayeats/area/application/service/AreaServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/area/application/service/AreaServiceTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -49,7 +50,7 @@ class AreaServiceTest {
             // given
             AreaCreateRequest request = new AreaCreateRequest("이태원", "서울특별시", "용산구");
 
-            given(areaRepository.existsByNameIgnoreCase("이태원"))
+            given(areaRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("이태원"))
                     .willReturn(false);
 
             given(areaRepository.save(any(Area.class)))
@@ -79,7 +80,7 @@ class AreaServiceTest {
             // given
             AreaCreateRequest request = new AreaCreateRequest("이태원", "서울특별시", "용산구");
 
-            given(areaRepository.existsByNameIgnoreCase("이태원"))
+            given(areaRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("이태원"))
                     .willReturn(true);
 
             // when & then
@@ -93,7 +94,7 @@ class AreaServiceTest {
             // given
             AreaCreateRequest request = new AreaCreateRequest("  이태원  ", "서울특별시", "용산구");
 
-            given(areaRepository.existsByNameIgnoreCase("이태원"))
+            given(areaRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("이태원"))
                     .willReturn(false);
 
             given(areaRepository.save(any(Area.class)))
@@ -113,6 +114,28 @@ class AreaServiceTest {
 
             // then
             assertThat(result.getName()).isEqualTo("이태원"); // trim 됐는지 확인
+        }
+
+        @Test
+        void 운영지역_이름이_null이면_예외() {
+            // given
+            AreaCreateRequest request = new AreaCreateRequest(null, "서울", "강남");
+
+            // when && then
+            assertThatThrownBy(() ->
+                    areaService.createArea(request)
+            ).isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 운영지역_이름이_공백이면_예외() {
+            // given
+            AreaCreateRequest request = new AreaCreateRequest("   ", "서울", "강남");
+
+            // when && then
+            assertThatThrownBy(() ->
+                    areaService.createArea(request)
+            ).isInstanceOf(BaseException.class);
         }
     }
 
@@ -268,7 +291,7 @@ class AreaServiceTest {
             given(areaRepository.findById(id))
                     .willReturn(Optional.of(area));
 
-            given(areaRepository.existsByNameIgnoreCase("광화문"))
+            given(areaRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("광화문"))
                     .willReturn(true);
 
             AreaUpdateRequest request = new AreaUpdateRequest("광화문", "서울특별시", "종로구", true);
@@ -321,6 +344,32 @@ class AreaServiceTest {
                     areaService.updateArea(id, request)
             ).isInstanceOf(BaseException.class);
         }
+
+        @Test
+        void 운영지역_수정시_이름이_null이면_예외() {
+            // given
+            UUID id = UUID.randomUUID();
+
+            Area area = Area.builder()
+                    .id(id)
+                    .name("이태원")
+                    .city("서울")
+                    .district("용산구")
+                    .isActive(true)
+                    .build();
+
+            given(areaRepository.findById(id)).willReturn(Optional.of(area));
+
+            AreaUpdateRequest request = new AreaUpdateRequest(null, "서울", "강남", true);
+
+            // when
+            Throwable thrown = catchThrowable(() ->
+                    areaService.updateArea(id, request)
+            );
+
+            // then
+            assertThat(thrown).isInstanceOf(BaseException.class);
+        }
     }
 
 
@@ -333,6 +382,7 @@ class AreaServiceTest {
         void 운영지역_삭제_성공() {
             // given
             UUID id = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
 
             Area area = Area.builder()
                     .id(id)
@@ -346,7 +396,7 @@ class AreaServiceTest {
                     .willReturn(Optional.of(area));
 
             // when
-            areaService.deleteArea(id);
+            areaService.deleteArea(id,userId);
 
             // then
             assertThat(area.isDeleted()).isTrue();
@@ -356,13 +406,14 @@ class AreaServiceTest {
         void 운영지역_삭제시_존재하지_않으면_예외발생() {
             // given
             UUID id = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
 
             given(areaRepository.findById(id))
                     .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() ->
-                    areaService.deleteArea(id)
+                    areaService.deleteArea(id, userId)
             ).isInstanceOf(BaseException.class);
         }
     }

--- a/src/test/java/com/sparta/todayeats/category/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/category/application/service/CategoryServiceTest.java
@@ -45,7 +45,7 @@ class CategoryServiceTest {
             // given
             CategoryCreateRequest request = new CategoryCreateRequest("한식");
 
-            given(categoryRepository.existsByNameIgnoreCase("한식"))
+            given(categoryRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("한식"))
                     .willReturn(false);
 
             given(categoryRepository.save(any(Category.class)))
@@ -70,7 +70,7 @@ class CategoryServiceTest {
             // given
             CategoryCreateRequest request = new CategoryCreateRequest("한식");
 
-            given(categoryRepository.existsByNameIgnoreCase("한식"))
+            given(categoryRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("한식"))
                     .willReturn(true);
 
             // when & then
@@ -78,6 +78,25 @@ class CategoryServiceTest {
                     categoryService.createCategory(request)
             ).isInstanceOf(BaseException.class);
         }
+
+        @Test
+        void 카테고리_이름이_null이면_예외() {
+            CategoryCreateRequest request = new CategoryCreateRequest(null);
+
+            assertThatThrownBy(() ->
+                    categoryService.createCategory(request)
+            ).isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 카테고리_이름이_공백이면_예외() {
+            CategoryCreateRequest request = new CategoryCreateRequest("   ");
+
+            assertThatThrownBy(() ->
+                    categoryService.createCategory(request)
+            ).isInstanceOf(BaseException.class);
+        }
+
     }
 
     // 카테고리 목록 조회
@@ -150,18 +169,18 @@ class CategoryServiceTest {
         @Test
         void 카테고리_단건조회_성공() {
             // given
-            UUID id = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
 
             Category category = Category.builder()
-                    .id(id)
+                    .id(categoryId)
                     .name("한식")
                     .build();
 
-            given(categoryRepository.findById(id))
+            given(categoryRepository.findById(categoryId))
                     .willReturn(Optional.of(category));
 
             // when
-            CategoryResponse result = categoryService.getCategory(id);
+            CategoryResponse result = categoryService.getCategory(categoryId);
 
             // then
             assertThat(result.getName()).isEqualTo("한식");
@@ -170,14 +189,14 @@ class CategoryServiceTest {
         @Test
         void 카테고리가_존재하지_않으면_예외발생() {
             // given
-            UUID id = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
 
-            given(categoryRepository.findById(id))
+            given(categoryRepository.findById(categoryId))
                     .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() ->
-                    categoryService.getCategory(id)
+                    categoryService.getCategory(categoryId)
             ).isInstanceOf(BaseException.class);
         }
     }
@@ -190,6 +209,46 @@ class CategoryServiceTest {
         @Test
         void 카테고리_수정_성공() {
             // given
+            UUID categoryId = UUID.randomUUID();
+
+            Category category = Category.builder()
+                    .id(categoryId)
+                    .name("한식")
+                    .build();
+
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(category));
+
+            CategoryUpdateRequest request =
+                    new CategoryUpdateRequest("중식");
+
+            // when
+            CategoryResponse result =
+                    categoryService.updateCategory(categoryId, request);
+
+            // then
+            assertThat(result.getName()).isEqualTo("중식");
+        }
+
+        @Test
+        void 카테고리_수정시_존재하지_않으면_예외발생() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.empty());
+
+            CategoryUpdateRequest request =
+                    new CategoryUpdateRequest("중식");
+
+            // when & then
+            assertThatThrownBy(() ->
+                    categoryService.updateCategory(categoryId, request)
+            ).isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 카테고리_수정시_이름이_중복이면_예외() {
             UUID id = UUID.randomUUID();
 
             Category category = Category.builder()
@@ -200,29 +259,11 @@ class CategoryServiceTest {
             given(categoryRepository.findById(id))
                     .willReturn(Optional.of(category));
 
-            CategoryUpdateRequest request =
-                    new CategoryUpdateRequest("중식");
+            given(categoryRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("중식"))
+                    .willReturn(true);
 
-            // when
-            CategoryResponse result =
-                    categoryService.updateCategory(id, request);
+            CategoryUpdateRequest request = new CategoryUpdateRequest("중식");
 
-            // then
-            assertThat(result.getName()).isEqualTo("중식");
-        }
-
-        @Test
-        void 카테고리_수정시_존재하지_않으면_예외발생() {
-            // given
-            UUID id = UUID.randomUUID();
-
-            given(categoryRepository.findById(id))
-                    .willReturn(Optional.empty());
-
-            CategoryUpdateRequest request =
-                    new CategoryUpdateRequest("중식");
-
-            // when & then
             assertThatThrownBy(() ->
                     categoryService.updateCategory(id, request)
             ).isInstanceOf(BaseException.class);
@@ -237,34 +278,36 @@ class CategoryServiceTest {
         @Test
         void 카테고리_삭제_성공() {
             // given
-            UUID id = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
 
             Category category = Category.builder()
-                    .id(id)
+                    .id(categoryId)
                     .name("한식")
                     .build();
 
-            given(categoryRepository.findById(id))
+            given(categoryRepository.findById(categoryId))
                     .willReturn(Optional.of(category));
 
             // when
-            categoryService.deleteCategory(id);
+            UUID userId = UUID.randomUUID();
+            categoryService.deleteCategory(categoryId, userId);
 
             // then
-            assertThat(category.isDeleted()).isTrue();
+            assertThat(category.getDeletedAt()).isNotNull();
         }
 
         @Test
         void 카테고리_삭제시_존재하지_않으면_예외발생() {
             // given
-            UUID id = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
 
-            given(categoryRepository.findById(id))
+            given(categoryRepository.findById(categoryId))
                     .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() ->
-                    categoryService.deleteCategory(id)
+                    categoryService.deleteCategory(categoryId, userId)
             ).isInstanceOf(BaseException.class);
         }
     }

--- a/src/test/java/com/sparta/todayeats/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/store/service/StoreServiceTest.java
@@ -28,7 +28,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class StoreServiceTest {
@@ -126,7 +131,7 @@ class StoreServiceTest {
                     category.getId()
             );
 
-            given(storeRepository.existsByNameIgnoreCase("맛있는 치킨")).willReturn(false);
+            given(storeRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("맛있는 치킨")).willReturn(false);
             given(userRepository.findById(userId)).willReturn(Optional.of(owner));
             given(areaRepository.findById(area.getId())).willReturn(Optional.of(area));
             given(categoryRepository.findById(category.getId())).willReturn(Optional.of(category));
@@ -156,16 +161,24 @@ class StoreServiceTest {
         void 가게_이름이_중복이면_예외발생() {
             // given
             UUID userId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
 
             StoreCreateRequest request = new StoreCreateRequest(
                     "맛있는 치킨",
                     "서울특별시 용산구 이태원로 123",
                     "02-1234-5678",
-                    UUID.randomUUID(),
+                    areaId,
                     UUID.randomUUID()
             );
 
-            given(storeRepository.existsByNameIgnoreCase("맛있는 치킨")).willReturn(true);
+            // Area mock — active 상태
+            Area mockArea = mock(Area.class);
+            given(mockArea.getIsActive()).willReturn(true);
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(mockArea));
+
+            // 이름 중복 → 예외 발생 포인트
+            given(storeRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("맛있는 치킨"))
+                    .willReturn(true);
 
             // when & then
             assertThatThrownBy(() ->
@@ -177,16 +190,27 @@ class StoreServiceTest {
         void 소유자가_존재하지_않으면_예외발생() {
             // given
             UUID userId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
 
             StoreCreateRequest request = new StoreCreateRequest(
                     "맛있는 치킨",
                     "서울특별시 용산구 이태원로 123",
                     "02-1234-5678",
-                    UUID.randomUUID(),
-                    UUID.randomUUID()
+                    areaId,
+                    categoryId
             );
 
-            given(storeRepository.existsByNameIgnoreCase("맛있는 치킨")).willReturn(false);
+            // Area mock — active 상태로 세팅
+            Area mockArea = mock(Area.class);
+            given(mockArea.getIsActive()).willReturn(true);
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(mockArea));
+
+            // 이름 중복 없음
+            given(storeRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("맛있는 치킨"))
+                    .willReturn(false);
+
+            // User 없음 → 예외 발생 포인트
             given(userRepository.findById(userId)).willReturn(Optional.empty());
 
             // when & then
@@ -206,38 +230,42 @@ class StoreServiceTest {
         void 가게_전체조회_성공() {
             // given
             Pageable pageable = PageRequest.of(0, 10);
-            User owner = createUser(UUID.randomUUID());
-            Area area = createArea();
-            Category category = createCategory();
-            Store store = createStore(owner, area, category);
 
-            Page<Store> pageResult = new PageImpl<>(List.of(store), pageable, 1);
+            Store store = createStore(createUser(UUID.randomUUID()), createArea(), createCategory());
 
-            given(storeRepository.searchStores(null, null, pageable)).willReturn(pageResult);
+            Page<Store> page = new PageImpl<>(List.of(store), pageable, 1);
+
+            given(storeRepository.searchStores(null, null, pageable, null, null))
+                    .willReturn(page);
 
             // when
-            PageResponse<StoreResponse> result = storeService.getStores(null, null, pageable);
+            PageResponse<StoreResponse> result =
+                    storeService.getStores(null, null, pageable, null, null);
 
             // then
             assertThat(result.getContent()).hasSize(1);
-            assertThat(result.getContent().get(0).getName()).isEqualTo("맛있는 치킨");
         }
 
         @Test
         void 카테고리_이름으로_검색조회_성공() {
             // given
             Pageable pageable = PageRequest.of(0, 10);
+
             User owner = createUser(UUID.randomUUID());
             Area area = createArea();
             Category category = createCategory();
+
             Store store = createStore(owner, area, category);
 
-            Page<Store> pageResult = new PageImpl<>(List.of(store), pageable, 1);
+            Page<Store> pageResult =
+                    new PageImpl<>(List.of(store), pageable, 1);
 
-            given(storeRepository.searchStores("한식", null, pageable)).willReturn(pageResult);
+            given(storeRepository.searchStores("한식", null, pageable, null, null))
+                    .willReturn(pageResult);
 
             // when
-            PageResponse<StoreResponse> result = storeService.getStores("한식", null, pageable);
+            PageResponse<StoreResponse> result =
+                    storeService.getStores("한식", null, pageable, null, null);
 
             // then
             assertThat(result.getContent()).hasSize(1);
@@ -255,10 +283,10 @@ class StoreServiceTest {
 
             Page<Store> pageResult = new PageImpl<>(List.of(store), pageable, 1);
 
-            given(storeRepository.searchStores(null, "치킨", pageable)).willReturn(pageResult);
+            given(storeRepository.searchStores(null, "치킨", pageable, null, null)).willReturn(pageResult);
 
             // when
-            PageResponse<StoreResponse> result = storeService.getStores(null, "치킨", pageable);
+            PageResponse<StoreResponse> result = storeService.getStores(null, "치킨", pageable,null,null);
 
             // then
             assertThat(result.getContent()).hasSize(1);
@@ -276,10 +304,10 @@ class StoreServiceTest {
 
             Page<Store> pageResult = new PageImpl<>(List.of(store), pageable, 1);
 
-            given(storeRepository.searchStores("한식", "치킨", pageable)).willReturn(pageResult);
+            given(storeRepository.searchStores("한식", "치킨", pageable,null,null)).willReturn(pageResult);
 
             // when
-            PageResponse<StoreResponse> result = storeService.getStores("한식", "치킨", pageable);
+            PageResponse<StoreResponse> result = storeService.getStores("한식", "치킨", pageable,null,null);
 
             // then
             assertThat(result.getContent()).hasSize(1);
@@ -305,7 +333,7 @@ class StoreServiceTest {
             given(storeRepository.findByIdWithOwner(storeId)).willReturn(Optional.of(store));
 
             // when
-            StoreResponse result = storeService.getStore(storeId);
+            StoreResponse result = storeService.getStore(storeId,null,null);
 
             // then
             assertThat(result.getName()).isEqualTo("맛있는 치킨");
@@ -321,7 +349,7 @@ class StoreServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    storeService.getStore(storeId)
+                    storeService.getStore(storeId,null,null)
             ).isInstanceOf(BaseException.class);
         }
     }
@@ -337,24 +365,25 @@ class StoreServiceTest {
             // given
             UUID userId = UUID.randomUUID();
             User owner = createUser(userId);
-            Area area = createArea();
-            Category category = createCategory();
-            Store store = createStore(owner, area, category);
+            Store store = createStore(owner, createArea(), createCategory());
 
             given(storeRepository.findByIdWithOwner(any())).willReturn(Optional.of(store));
+            given(storeRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("수정된 치킨집")).willReturn(false);
+
+            // Authentication mock
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getAuthorities())
+                    .willReturn((Collection) List.of(new SimpleGrantedAuthority("ROLE_OWNER")));
 
             StoreUpdateRequest request = new StoreUpdateRequest(
-                    "수정된 치킨집",
-                    "서울특별시 용산구 이태원로 999",
-                    "02-9999-9999"
+                    "수정된 치킨집", "서울특별시 용산구 이태원로 999", "02-9999-9999"
             );
 
             // when
-            StoreResponse result = storeService.updateStore(UUID.randomUUID(), request, userId);
+            StoreResponse result = storeService.updateStore(UUID.randomUUID(), request, userId, authentication);
 
             // then
             assertThat(result.getName()).isEqualTo("수정된 치킨집");
-            assertThat(result.getAddress()).isEqualTo("서울특별시 용산구 이태원로 999");
         }
 
         @Test
@@ -367,6 +396,11 @@ class StoreServiceTest {
 
             given(storeRepository.findByIdWithOwner(any())).willReturn(Optional.of(store));
 
+            // OWNER 권한 → isManagerOrMaster = false → 소유자 체크 진입
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getAuthorities())
+                    .willReturn((Collection) List.of(new SimpleGrantedAuthority("ROLE_OWNER")));
+
             StoreUpdateRequest request = new StoreUpdateRequest(
                     "수정된 치킨집",
                     "서울특별시 용산구 이태원로 999",
@@ -375,7 +409,7 @@ class StoreServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    storeService.updateStore(UUID.randomUUID(), request, otherUserId)
+                    storeService.updateStore(UUID.randomUUID(), request, otherUserId,authentication)
             ).isInstanceOf(BaseException.class);
         }
 
@@ -394,7 +428,7 @@ class StoreServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    storeService.updateStore(UUID.randomUUID(), request, userId)
+                    storeService.updateStore(UUID.randomUUID(), request, userId,null)
             ).isInstanceOf(BaseException.class);
         }
     }
@@ -414,8 +448,12 @@ class StoreServiceTest {
 
             given(storeRepository.findByIdWithOwner(any())).willReturn(Optional.of(store));
 
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getAuthorities())
+                    .willReturn((Collection) List.of(new SimpleGrantedAuthority("ROLE_OWNER")));
+
             // when
-            storeService.deleteStore(UUID.randomUUID(), userId);
+            storeService.deleteStore(UUID.randomUUID(), userId,authentication);
 
             // then
             assertThat(store.isDeleted()).isTrue();
@@ -431,9 +469,14 @@ class StoreServiceTest {
 
             given(storeRepository.findByIdWithOwner(any())).willReturn(Optional.of(store));
 
+            // OWNER 권한 → isMaster = false → 소유자 체크 진입
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getAuthorities())
+                    .willReturn((Collection) List.of(new SimpleGrantedAuthority("ROLE_OWNER")));
+
             // when & then
             assertThatThrownBy(() ->
-                    storeService.deleteStore(UUID.randomUUID(), otherUserId)
+                    storeService.deleteStore(UUID.randomUUID(), otherUserId,authentication)
             ).isInstanceOf(BaseException.class);
         }
 
@@ -446,7 +489,7 @@ class StoreServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    storeService.deleteStore(UUID.randomUUID(), userId)
+                    storeService.deleteStore(UUID.randomUUID(), userId,null)
             ).isInstanceOf(BaseException.class);
         }
     }
@@ -466,10 +509,15 @@ class StoreServiceTest {
 
             given(storeRepository.findByIdWithOwner(any())).willReturn(Optional.of(store));
 
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getAuthorities())
+                    .willReturn((Collection) List.of(new SimpleGrantedAuthority("ROLE_OWNER")));
+
+
             StoreHiddenRequest request = new StoreHiddenRequest(true);
 
             // when
-            StoreHiddenResponse result = storeService.updateHidden(UUID.randomUUID(), request, userId);
+            StoreHiddenResponse result = storeService.updateHidden(UUID.randomUUID(), request, userId,authentication);
 
             // then
             assertThat(result.getIsHidden()).isTrue();
@@ -485,10 +533,14 @@ class StoreServiceTest {
 
             given(storeRepository.findByIdWithOwner(any())).willReturn(Optional.of(store));
 
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getAuthorities())
+                    .willReturn((Collection) List.of(new SimpleGrantedAuthority("ROLE_OWNER")));
+
             StoreHiddenRequest request = new StoreHiddenRequest(false);
 
             // when
-            StoreHiddenResponse result = storeService.updateHidden(UUID.randomUUID(), request, userId);
+            StoreHiddenResponse result = storeService.updateHidden(UUID.randomUUID(), request, userId,authentication);
 
             // then
             assertThat(result.getIsHidden()).isFalse();
@@ -504,11 +556,16 @@ class StoreServiceTest {
 
             given(storeRepository.findByIdWithOwner(any())).willReturn(Optional.of(store));
 
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getAuthorities())
+                    .willReturn((Collection) List.of(new SimpleGrantedAuthority("ROLE_OWNER")));
+
+
             StoreHiddenRequest request = new StoreHiddenRequest(true);
 
             // when & then
             assertThatThrownBy(() ->
-                    storeService.updateHidden(UUID.randomUUID(), request, otherUserId)
+                    storeService.updateHidden(UUID.randomUUID(), request, otherUserId,authentication)
             ).isInstanceOf(BaseException.class);
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
#39 


## ✨ 요약

- 모든 API에 Auditing 처리 수정
- JWT 인증 적용
- 카테고리 생성 (MANAGER, MASTER)
- 카테고리 수정 (MANAGER, MASTER)
- 카테고리 삭제 - 권한 (MASTER)
- 운영 지역 생성 (MANAGER, MASTER)
- 운영 지역 수정 (MANAGER, MASTER)
- 운영 지역 삭제 (MASTER)
- 가게 생성 (OWNER)
- 가게 수정 (OWNER(본인)/MANAGER/MASTER)
- 가게 삭제 (OWNER(본인)/MANAGER/MASTER)


## 상세 내용
### 전체 
- GlobalExceptionHandler 수정: 접근 권한, HTTP메서드, 경로 추가 
- JpaConfig 수정: 현재 로그인한 사용자의 UUID를 Auditing에 제공하기 위해 코드 추가 
- securityConfig에 @EnableMethodSecurity 추가 : 권한처리 @PreAuthorize 를 사용하기 위해 추가 
- @AuthenticationPrincipal -> @LoginUser로 통일 

### store 
- 가게 생성
    - 비활성화된 운영 지역이면 생성 불가 
    - 가게 이름 중복 체크 시 소프트 삭제된 가게 제외 체크 
- 가게 조회 
    - 권한에 따라 노충 범위 다르게 처리 
    - CUSTOMER, 비로그인 → 공개 가게만
    - OWNER → 본인 가게 + 공개
    - MANAGER, MASTER → 전체 (숨김 포함)
 - 가게 수정/삭제/숨김 
     - OWNER는 본인 가게만 수정, 삭제, 숨김 가능 
 


## 📸 스크린샷(선택)
없음

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
없음

Closes #39 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-based access enforced for area, category, and store operations; authenticated user ID used for mutating actions.
  * Auditing support added to capture acting user.
  * Store listing now respects caller role for hidden-store visibility.

* **Bug Fixes**
  * Uniqueness checks now ignore soft-deleted records, allowing reuse of names after deletion.
  * Prevent creating stores in inactive areas.
  * Global handlers improved for 403/404/405 responses and error code additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->