### PR TITLE
[feat] 주문 생성 시 결제 연동 및 예외처리 보완

### DIFF
--- a/src/main/java/com/sparta/todayeats/global/exception/PaymentErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/PaymentErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAY-001", "결제에 실패했습니다."),
     PAYMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "PAY-002", "이미 결제된 주문입니다."),
-    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY-003", "결제 내역을 찾을 수 없습니다.");
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY-003", "결제 내역을 찾을 수 없습니다."),
+    INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "PAY-004", "환불 불가능한 결제 상태입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/todayeats/menu/repository/MenuRepository.java
@@ -79,11 +79,13 @@ public interface MenuRepository extends JpaRepository<Menu, UUID> {
             Pageable pageable
     );
 
-    // 주문 서비스용 - 삭제되지 않은 메뉴 단건 조회
+    // 주문 서비스용 - 삭제/숨김/품절 제외 메뉴 단건 조회
     @Query("""
         SELECT m FROM Menu m
         WHERE m.id = :menuId
         AND m.deletedAt IS NULL
+        AND m.isHidden = false
+        AND m.soldOut = false
     """)
     Optional<Menu> findActiveById(@Param("menuId") UUID menuId);
 }

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -333,8 +333,15 @@ public class OrderService {
 
         Order order = findActiveOrder(orderId);
 
-        // 결제 완료 상태면 환불 처리
-        paymentService.refund(orderId);
+        // 결제 완료 상태면 환불 처리 (결제 없는 기존 주문은 무시)
+        try {
+            paymentService.refund(orderId);
+        } catch (BaseException e) {
+            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND) {
+                throw e;
+            }
+            log.debug("No payment found for order {}, skipping refund", orderId);
+        }
 
         order.delete(userId);
 

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -12,7 +12,9 @@ import com.sparta.todayeats.order.repository.OrderRepository;
 import com.sparta.todayeats.order.dto.request.*;
 import com.sparta.todayeats.order.dto.response.*;
 import com.sparta.todayeats.payment.dto.request.PaymentCreateRequest;
+import com.sparta.todayeats.payment.dto.response.PaymentCreateResponse;
 import com.sparta.todayeats.payment.entity.PaymentMethod;
+import com.sparta.todayeats.payment.entity.PaymentStatus;
 import com.sparta.todayeats.payment.service.PaymentService;
 import com.sparta.todayeats.store.entity.Store;
 import com.sparta.todayeats.store.repository.StoreRepository;
@@ -110,7 +112,11 @@ public class OrderService {
         Order saved = orderRepository.save(order);
 
         // 주문 생성과 함께 결제 처리 (기본 결제 수단: CARD)
-        paymentService.createPayment(saved.getOrderId(), userId, new PaymentCreateRequest(PaymentMethod.CARD));
+        PaymentCreateResponse payment = paymentService.createPayment(
+                saved.getOrderId(), userId, new PaymentCreateRequest(PaymentMethod.CARD));
+        if (payment.getStatus() != PaymentStatus.COMPLETED) {
+            throw new BaseException(PaymentErrorCode.PAYMENT_FAILED);
+        }
 
         log.info("주문 생성 완료: orderId={}, userId={}, total={}", saved.getOrderId(), userId, total);
         return CreateOrderResponse.from(saved);

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -62,7 +62,7 @@ public class OrderService {
         }
 
         // 배송지 조회 및 검증 (주소 스냅샷용)
-        Address address = addressRepository.findByUserUserIdAndIsDefaultTrue(userId)
+        Address address = addressRepository.findActiveById(request.addressId())
                 .orElseThrow(() -> new BaseException(AddressErrorCode.ADDRESS_NOT_FOUND));
         if (!address.getUser().getUserId().equals(userId)) {
             throw new BaseException(CommonErrorCode.FORBIDDEN);

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -11,6 +11,9 @@ import com.sparta.todayeats.order.entity.OrderStatus;
 import com.sparta.todayeats.order.repository.OrderRepository;
 import com.sparta.todayeats.order.dto.request.*;
 import com.sparta.todayeats.order.dto.response.*;
+import com.sparta.todayeats.payment.dto.request.PaymentCreateRequest;
+import com.sparta.todayeats.payment.entity.PaymentMethod;
+import com.sparta.todayeats.payment.service.PaymentService;
 import com.sparta.todayeats.store.entity.Store;
 import com.sparta.todayeats.store.repository.StoreRepository;
 import com.sparta.todayeats.user.entity.UserRoleEnum;
@@ -36,6 +39,7 @@ public class OrderService {
     private final MenuRepository menuRepository;
     private final StoreRepository storeRepository;
     private final AddressRepository addressRepository;
+    private final PaymentService paymentService;
 
     /**
      * 주문 생성
@@ -105,9 +109,8 @@ public class OrderService {
         order.updateTotalPrice(total);
         Order saved = orderRepository.save(order);
 
-        // TODO: Payment 담당자 코드 완성 후 주석 해제
-        // 주문 생성 시 결제 생성 같이 처리 (트랜잭션 묶음)
-        // paymentService.createPayment(saved.getOrderId(), total);
+        // 주문 생성과 함께 결제 처리 (기본 결제 수단: CARD)
+        paymentService.createPayment(saved.getOrderId(), userId, new PaymentCreateRequest(PaymentMethod.CARD));
 
         log.info("주문 생성 완료: orderId={}, userId={}, total={}", saved.getOrderId(), userId, total);
         return CreateOrderResponse.from(saved);
@@ -266,9 +269,8 @@ public class OrderService {
             throw new BaseException(OrderErrorCode.ORDER_CONFLICT);
         }
 
-        // TODO: Payment 코드 완성 후 주석 해제
         // 주문 취소 시 환불 처리 같이 처리 (트랜잭션 묶음)
-        // paymentService.refund(orderId);
+        paymentService.refund(orderId);
 
         Order updated = findActiveOrder(orderId);
         log.info("주문 취소: orderId={}", orderId);
@@ -308,9 +310,8 @@ public class OrderService {
             throw new BaseException(OrderErrorCode.ORDER_CONFLICT);
         }
 
-        // TODO: Payment 코드 완성 후 주석 해제
         // 주문 거절 시 환불 처리 같이 처리 (트랜잭션 묶음)
-        // paymentService.refund(orderId);
+        paymentService.refund(orderId);
 
         Order updated = findActiveOrder(orderId);
         log.info("주문 거절: orderId={}", orderId);
@@ -332,9 +333,8 @@ public class OrderService {
 
         Order order = findActiveOrder(orderId);
 
-        // TODO: Payment 코드 완성 후 주석 해제
         // 결제 완료 상태면 환불 처리
-        // paymentService.refundIfPaid(orderId);
+        paymentService.refund(orderId);
 
         order.delete(userId);
 

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -357,10 +357,11 @@ public class OrderService {
         try {
             paymentService.refund(orderId);
         } catch (BaseException e) {
-            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND) {
+            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND
+                    && e.getErrorCode() != PaymentErrorCode.INVALID_PAYMENT_STATUS) {
                 throw e;
             }
-            log.debug("No payment found for order {}, skipping refund", orderId);
+            log.debug("Skipping refund for order {} due to payment state: {}", orderId, e.getErrorCode());
         }
 
         order.delete(userId);

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -269,8 +269,15 @@ public class OrderService {
             throw new BaseException(OrderErrorCode.ORDER_CONFLICT);
         }
 
-        // 주문 취소 시 환불 처리 같이 처리 (트랜잭션 묶음)
-        paymentService.refund(orderId);
+        // 주문 취소 시 환불 처리 (결제 없는 기존 주문은 무시)
+        try {
+            paymentService.refund(orderId);
+        } catch (BaseException e) {
+            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND) {
+                throw e;
+            }
+            log.debug("No payment found for order {}, skipping refund", orderId);
+        }
 
         Order updated = findActiveOrder(orderId);
         log.info("주문 취소: orderId={}", orderId);
@@ -310,8 +317,15 @@ public class OrderService {
             throw new BaseException(OrderErrorCode.ORDER_CONFLICT);
         }
 
-        // 주문 거절 시 환불 처리 같이 처리 (트랜잭션 묶음)
-        paymentService.refund(orderId);
+        // 주문 거절 시 환불 처리 (결제 없는 기존 주문은 무시)
+        try {
+            paymentService.refund(orderId);
+        } catch (BaseException e) {
+            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND) {
+                throw e;
+            }
+            log.debug("No payment found for order {}, skipping refund", orderId);
+        }
 
         Order updated = findActiveOrder(orderId);
         log.info("주문 거절: orderId={}", orderId);

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -275,15 +275,8 @@ public class OrderService {
             throw new BaseException(OrderErrorCode.ORDER_CONFLICT);
         }
 
-        // 주문 취소 시 환불 처리 (결제 없는 기존 주문은 무시)
-        try {
-            paymentService.refund(orderId);
-        } catch (BaseException e) {
-            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND) {
-                throw e;
-            }
-            log.debug("No payment found for order {}, skipping refund", orderId);
-        }
+        // 주문 취소 시 환불 처리
+        refundIfPossible(orderId);
 
         Order updated = findActiveOrder(orderId);
         log.info("주문 취소: orderId={}", orderId);
@@ -323,15 +316,8 @@ public class OrderService {
             throw new BaseException(OrderErrorCode.ORDER_CONFLICT);
         }
 
-        // 주문 거절 시 환불 처리 (결제 없는 기존 주문은 무시)
-        try {
-            paymentService.refund(orderId);
-        } catch (BaseException e) {
-            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND) {
-                throw e;
-            }
-            log.debug("No payment found for order {}, skipping refund", orderId);
-        }
+        // 주문 거절 시 환불 처리
+        refundIfPossible(orderId);
 
         Order updated = findActiveOrder(orderId);
         log.info("주문 거절: orderId={}", orderId);
@@ -353,16 +339,8 @@ public class OrderService {
 
         Order order = findActiveOrder(orderId);
 
-        // 결제 완료 상태면 환불 처리 (결제 없는 기존 주문은 무시)
-        try {
-            paymentService.refund(orderId);
-        } catch (BaseException e) {
-            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND
-                    && e.getErrorCode() != PaymentErrorCode.INVALID_PAYMENT_STATUS) {
-                throw e;
-            }
-            log.debug("Skipping refund for order {} due to payment state: {}", orderId, e.getErrorCode());
-        }
+        // 주문 삭제 시 환불 처리
+        refundIfPossible(orderId);
 
         order.delete(userId);
 
@@ -398,6 +376,24 @@ public class OrderService {
                 .orElseThrow(() -> new BaseException(StoreErrorCode.STORE_NOT_FOUND));
         if (!store.getOwner().getUserId().equals(userId)) {
             throw new BaseException(CommonErrorCode.FORBIDDEN);
+        }
+    }
+
+    /**
+     * 환불 처리 (결제 상태에 따라 무시 가능)
+     * - PAYMENT_NOT_FOUND: 결제가 없는 주문 (현재 구현상 발생 불가, 확장 대비) → 무시
+     * - INVALID_PAYMENT_STATUS: 아직 결제가 완료되지 않은 상태 (PENDING 등) → 무시
+     * - 그 외 예외는 그대로 전파
+     */
+    private void refundIfPossible(UUID orderId) {
+        try {
+            paymentService.refund(orderId);
+        } catch (BaseException e) {
+            if (e.getErrorCode() != PaymentErrorCode.PAYMENT_NOT_FOUND
+                    && e.getErrorCode() != PaymentErrorCode.INVALID_PAYMENT_STATUS) {
+                throw e;
+            }
+            log.debug("Skipping refund for order {} due to payment state: {}", orderId, e.getErrorCode());
         }
     }
 }

--- a/src/main/java/com/sparta/todayeats/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/todayeats/payment/repository/PaymentRepository.java
@@ -25,4 +25,7 @@ public interface PaymentRepository extends JpaRepository<Payment, UUID> {
 
     // 단일 조회
     Optional<Payment> findByIdAndOrder_CustomerIdAndDeletedAtIsNull(UUID paymentId, UUID customerId);
+
+    // 주문 ID로 결제 조회 (환불 및 중복 결제 방지용)
+    Optional<Payment> findByOrder_OrderIdAndDeletedAtIsNull(UUID orderId);
 }

--- a/src/main/java/com/sparta/todayeats/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/todayeats/payment/service/PaymentService.java
@@ -41,27 +41,32 @@ public class PaymentService {
         Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new BaseException(OrderErrorCode.ORDER_NOT_FOUND));
 
-        // 2. 본인 주문인지 검증
+        // 2. 동일 주문에 대한 중복 결제 방지
+        if (paymentRepository.findByOrder_OrderIdAndDeletedAtIsNull(orderId).isPresent()) {
+            throw new BaseException(PaymentErrorCode.PAYMENT_ALREADY_EXISTS);
+        }
+
+        // 3. 본인 주문인지 검증
         if (!order.getCustomerId().equals(userId)) {
             throw new BaseException(OrderErrorCode.ORDER_ACCESS_DENIED);
         }
 
-        // 3. 주문 상태 검증
+        // 4. 주문 상태 검증
         if (order.getStatus() == OrderStatus.CANCELED) {
             throw new BaseException(OrderErrorCode.ORDER_ALREADY_CANCELLED);
         }
 
-        // 4. 결제 엔티티 생성 (PENDING)
+        // 5. 결제 엔티티 생성 (PENDING)
         Payment payment = Payment.builder()
                 .order(order)
                 .amount(order.getTotalPrice())
                 .build();
         paymentRepository.save(payment);
 
-        // 5. 결제 처리 (실제 구현X)
+        // 6. 결제 처리 (실제 구현X)
         boolean success = true;
 
-        // 6. payment status 갱신
+        // 7. payment status 갱신
         if (success) {
             payment.updatePaymentStatus(PaymentStatus.COMPLETED);
         } else {
@@ -151,5 +156,13 @@ public class PaymentService {
                 .orElseThrow(() -> new BaseException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         payment.softDelete(userId);
+    }
+
+    // 환불 처리 - 결제 상태를 CANCELLED로 변경 (실제 PG 연동 없이 DB 상태값만 변경)
+    @Transactional
+    public void refund(UUID orderId) {
+        Payment payment = paymentRepository.findByOrder_OrderIdAndDeletedAtIsNull(orderId)
+                .orElseThrow(() -> new BaseException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        payment.updatePaymentStatus(PaymentStatus.CANCELLED);
     }
 }

--- a/src/main/java/com/sparta/todayeats/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/todayeats/payment/service/PaymentService.java
@@ -163,6 +163,14 @@ public class PaymentService {
     public void refund(UUID orderId) {
         Payment payment = paymentRepository.findByOrder_OrderIdAndDeletedAtIsNull(orderId)
                 .orElseThrow(() -> new BaseException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() == PaymentStatus.CANCELLED) {
+            return; // 이미 환불된 상태 → 멱등 처리
+        }
+        if (payment.getStatus() != PaymentStatus.COMPLETED) {
+            throw new BaseException(PaymentErrorCode.INVALID_PAYMENT_STATUS); // PENDING 등 환불 불가 상태
+        }
+
         payment.updatePaymentStatus(PaymentStatus.CANCELLED);
     }
 }

--- a/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
@@ -13,6 +13,7 @@ import com.sparta.todayeats.order.entity.OrderType;
 import com.sparta.todayeats.order.repository.OrderRepository;
 import com.sparta.todayeats.payment.dto.response.PaymentCreateResponse;
 import com.sparta.todayeats.payment.entity.PaymentMethod;
+import com.sparta.todayeats.payment.entity.PaymentStatus;
 import com.sparta.todayeats.payment.service.PaymentService;
 import com.sparta.todayeats.store.entity.Store;
 import com.sparta.todayeats.store.repository.StoreRepository;
@@ -142,7 +143,9 @@ class OrderServiceTest {
                     .willAnswer(inv -> inv.getArgument(0));
             given(paymentService.createPayment(any(), eq(userId),
                     argThat(req -> req.getPaymentMethod() == PaymentMethod.CARD)))
-                    .willReturn(mock(PaymentCreateResponse.class));
+                    .willReturn(PaymentCreateResponse.builder()
+                            .status(PaymentStatus.COMPLETED)
+                            .build());
 
             // when
             CreateOrderResponse result = orderService.createOrder(createOrderRequest(), userId, UserRoleEnum.CUSTOMER);

--- a/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
@@ -12,6 +12,7 @@ import com.sparta.todayeats.order.entity.OrderStatus;
 import com.sparta.todayeats.order.entity.OrderType;
 import com.sparta.todayeats.order.repository.OrderRepository;
 import com.sparta.todayeats.payment.dto.response.PaymentCreateResponse;
+import com.sparta.todayeats.payment.entity.PaymentMethod;
 import com.sparta.todayeats.payment.service.PaymentService;
 import com.sparta.todayeats.store.entity.Store;
 import com.sparta.todayeats.store.repository.StoreRepository;
@@ -139,7 +140,8 @@ class OrderServiceTest {
                     .willReturn(Optional.of(mockMenu));
             given(orderRepository.save(any(Order.class)))
                     .willAnswer(inv -> inv.getArgument(0));
-            given(paymentService.createPayment(any(), eq(userId), any()))
+            given(paymentService.createPayment(any(), eq(userId),
+                    argThat(req -> req.getPaymentMethod() == PaymentMethod.CARD)))
                     .willReturn(mock(PaymentCreateResponse.class));
 
             // when
@@ -1277,6 +1279,23 @@ class OrderServiceTest {
             assertThat(order.isDeleted()).isTrue();
             assertThat(order.getDeletedAt()).isNotNull();
             assertThat(order.getDeletedBy()).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("성공 - 결제 없는 주문 soft delete (레거시 호환)")
+        void 결제_없는_주문_soft_delete_성공() {
+            // given
+            Order order = pendingOrder();
+            given(orderRepository.findActiveById(orderId))
+                    .willReturn(Optional.of(order));
+            willThrow(new BaseException(PaymentErrorCode.PAYMENT_NOT_FOUND))
+                    .given(paymentService).refund(any());
+
+            // when
+            orderService.deleteOrder(orderId, userId, UserRoleEnum.MASTER);
+
+            // then
+            assertThat(order.isDeleted()).isTrue();
         }
 
         @Test

--- a/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
@@ -133,7 +133,7 @@ class OrderServiceTest {
             User mockUser = mock(User.class);
             given(mockUser.getUserId()).willReturn(userId);
             given(mockAddress.getUser()).willReturn(mockUser);
-            given(addressRepository.findByUserUserIdAndIsDefaultTrue(userId)).willReturn(Optional.of(mockAddress));
+            given(addressRepository.findActiveById(addressId)).willReturn(Optional.of(mockAddress));
 
             given(menuRepository.findActiveById(menuId))
                     .willReturn(Optional.of(mockMenu));
@@ -171,7 +171,7 @@ class OrderServiceTest {
             // given
             given(storeRepository.findById(storeId))
                     .willReturn(Optional.of(mock(Store.class)));
-            given(addressRepository.findByUserUserIdAndIsDefaultTrue(userId))
+            given(addressRepository.findActiveById(addressId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -192,8 +192,7 @@ class OrderServiceTest {
             User mockUser = mock(User.class);
             given(mockUser.getUserId()).willReturn(userId);
             given(mockAddress.getUser()).willReturn(mockUser);
-            given(addressRepository.findByUserUserIdAndIsDefaultTrue(userId))
-                    .willReturn(Optional.of(mockAddress));
+            given(addressRepository.findActiveById(addressId)).willReturn(Optional.of(mockAddress));
 
             given(menuRepository.findActiveById(menuId))
                     .willReturn(Optional.empty());
@@ -222,8 +221,7 @@ class OrderServiceTest {
             User mockUser = mock(User.class);
             given(mockUser.getUserId()).willReturn(userId);
             given(mockAddress.getUser()).willReturn(mockUser);
-            given(addressRepository.findByUserUserIdAndIsDefaultTrue(userId))
-                    .willReturn(Optional.of(mockAddress));
+            given(addressRepository.findActiveById(addressId)).willReturn(Optional.of(mockAddress));
 
             given(menuRepository.findActiveById(menuId))
                     .willReturn(Optional.of(mockMenu));
@@ -271,7 +269,8 @@ class OrderServiceTest {
             User otherUser = mock(User.class);
             given(otherUser.getUserId()).willReturn(UUID.randomUUID()); // 다른 유저 ID
             given(mockAddress.getUser()).willReturn(otherUser);
-            given(addressRepository.findByUserUserIdAndIsDefaultTrue(userId)).willReturn(Optional.of(mockAddress));
+            given(addressRepository.findActiveById(addressId)).willReturn(Optional.of(mockAddress));
+
             // when & then
             assertThatThrownBy(() -> orderService.createOrder(
                     createOrderRequest(), userId, UserRoleEnum.CUSTOMER))

--- a/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
@@ -1078,6 +1078,7 @@ class OrderServiceTest {
                     .willReturn(Optional.of(canceledOrder));
             given(orderRepository.cancelConditionally(eq(orderId), eq("단순 변심"), eq(OrderStatus.PENDING.name()), eq(OrderStatus.CANCELED.name()), eq(userId)))
                     .willReturn(1);
+            willDoNothing().given(paymentService).refund(any());
 
             // when
             CancelOrderResponse result = orderService.cancelOrder(

--- a/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
@@ -11,6 +11,8 @@ import com.sparta.todayeats.order.entity.Order;
 import com.sparta.todayeats.order.entity.OrderStatus;
 import com.sparta.todayeats.order.entity.OrderType;
 import com.sparta.todayeats.order.repository.OrderRepository;
+import com.sparta.todayeats.payment.dto.response.PaymentCreateResponse;
+import com.sparta.todayeats.payment.service.PaymentService;
 import com.sparta.todayeats.store.entity.Store;
 import com.sparta.todayeats.store.repository.StoreRepository;
 import com.sparta.todayeats.user.entity.User;
@@ -60,6 +62,8 @@ class OrderServiceTest {
     private StoreRepository storeRepository;
     @Mock
     private AddressRepository addressRepository;
+    @Mock
+    private PaymentService paymentService;
 
     private CreateOrderRequest createOrderRequest() {
         return new CreateOrderRequest(
@@ -135,6 +139,8 @@ class OrderServiceTest {
                     .willReturn(Optional.of(mockMenu));
             given(orderRepository.save(any(Order.class)))
                     .willAnswer(inv -> inv.getArgument(0));
+            given(paymentService.createPayment(any(), eq(userId), any()))
+                    .willReturn(mock(PaymentCreateResponse.class));
 
             // when
             CreateOrderResponse result = orderService.createOrder(createOrderRequest(), userId, UserRoleEnum.CUSTOMER);
@@ -870,6 +876,7 @@ class OrderServiceTest {
                     .willReturn(Optional.of(canceledOrder));
             given(orderRepository.cancelConditionally(eq(orderId), eq("단순 변심"), eq(OrderStatus.PENDING.name()), eq(OrderStatus.CANCELED.name()), eq(userId)))
                     .willReturn(1);
+            willDoNothing().given(paymentService).refund(any());
 
             // when
             CancelOrderResponse result = orderService.cancelOrder(
@@ -893,6 +900,7 @@ class OrderServiceTest {
                     .willReturn(Optional.of(canceledOrder));
             given(orderRepository.cancelConditionally(eq(orderId), isNull(), eq(OrderStatus.PENDING.name()), eq(OrderStatus.CANCELED.name()), eq(userId)))
                     .willReturn(1);
+            willDoNothing().given(paymentService).refund(any());
 
             // when
             CancelOrderResponse result = orderService.cancelOrder(orderId, null, userId, UserRoleEnum.CUSTOMER);
@@ -1107,6 +1115,7 @@ class OrderServiceTest {
                     .willReturn(Optional.of(pendingOrder()))
                     .willReturn(Optional.of(rejectedOrder));
             given(orderRepository.rejectConditionally(eq(orderId), eq("재료 소진"), eq(OrderStatus.PENDING), eq(OrderStatus.REJECTED), eq(userId))).willReturn(1);
+            willDoNothing().given(paymentService).refund(any());
 
             // when
             RejectOrderResponse result = orderService.rejectOrder(orderId, new RejectOrderRequest("재료 소진"), userId, UserRoleEnum.OWNER);
@@ -1133,6 +1142,7 @@ class OrderServiceTest {
                     .willReturn(Optional.of(pendingOrder()))
                     .willReturn(Optional.of(rejectedOrder));
             given(orderRepository.rejectConditionally(eq(orderId), isNull(), eq(OrderStatus.PENDING), eq(OrderStatus.REJECTED), eq(userId))).willReturn(1);
+            willDoNothing().given(paymentService).refund(any());
 
             // when
             RejectOrderResponse result = orderService.rejectOrder(orderId, null, userId, UserRoleEnum.OWNER);
@@ -1155,6 +1165,7 @@ class OrderServiceTest {
                     .willReturn(Optional.of(rejectedOrder));
             given(orderRepository.rejectConditionally(eq(orderId), eq("운영자 거절"), eq(OrderStatus.PENDING), eq(OrderStatus.REJECTED), eq(userId)))
                     .willReturn(1);
+            willDoNothing().given(paymentService).refund(any());
 
             // when
             RejectOrderResponse result = orderService.rejectOrder(orderId, new RejectOrderRequest("운영자 거절"), userId, UserRoleEnum.MASTER);
@@ -1257,6 +1268,7 @@ class OrderServiceTest {
             Order order = pendingOrder();
             given(orderRepository.findActiveById(orderId))
                     .willReturn(Optional.of(order));
+            willDoNothing().given(paymentService).refund(any());
 
             // when
             orderService.deleteOrder(orderId, userId, UserRoleEnum.MASTER);

--- a/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/order/service/OrderServiceTest.java
@@ -888,6 +888,7 @@ class OrderServiceTest {
 
             // then
             assertThat(result.status()).isEqualTo(OrderStatus.CANCELED);
+            then(paymentService).should().refund(orderId);
         }
 
         @Test
@@ -911,6 +912,7 @@ class OrderServiceTest {
 
             // then
             assertThat(result.status()).isEqualTo(OrderStatus.CANCELED);
+            then(paymentService).should().refund(orderId);
         }
 
         @Test
@@ -1091,6 +1093,7 @@ class OrderServiceTest {
 
             // then
             assertThat(result.status()).isEqualTo(OrderStatus.CANCELED);
+            then(paymentService).should().refund(orderId);
         }
     }
 
@@ -1128,6 +1131,7 @@ class OrderServiceTest {
             // then
             assertThat(result.status()).isEqualTo(OrderStatus.REJECTED);
             assertThat(result.rejectReason()).isEqualTo("재료 소진");
+            then(paymentService).should().refund(orderId);
         }
 
         @Test
@@ -1155,6 +1159,7 @@ class OrderServiceTest {
             // then
             assertThat(result.status()).isEqualTo(OrderStatus.REJECTED);
             assertThat(result.rejectReason()).isNull();
+            then(paymentService).should().refund(orderId);
         }
 
         @Test
@@ -1178,6 +1183,7 @@ class OrderServiceTest {
             // then
             assertThat(result.status()).isEqualTo(OrderStatus.REJECTED);
             assertThat(result.rejectReason()).isEqualTo("운영자 거절");
+            then(paymentService).should().refund(orderId);
         }
 
         @Test
@@ -1282,6 +1288,7 @@ class OrderServiceTest {
             assertThat(order.isDeleted()).isTrue();
             assertThat(order.getDeletedAt()).isNotNull();
             assertThat(order.getDeletedBy()).isEqualTo(userId);
+            then(paymentService).should().refund(orderId);
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈                                                                                                                                                       
#51
                                                                                                                                                                        
                  
## ✨ 요약
  - 주문 생성 시 결제 자동 생성 연동
  - 주문 취소/거절/삭제 시 환불 처리 연동
  - 동일 주문 중복 결제 방지
  - 숨김/품절 메뉴 주문 차단
  - 주문 생성 시 배송지 조회 방식 복원 (addressId 직접 지정)
  - 테스트 코드 보완


## 상세 내용
  - createOrder: 주문 생성과 동시에 결제 자동 생성 (CARD, 트랜잭션 묶음)
  - cancelOrder: 주문 취소 시 환불 처리 연동
  - rejectOrder: 주문 거절 시 환불 처리 연동
  - deleteOrder: 주문 삭제 시 환불 처리 연동
  - PaymentService.createPayment: 동일 주문 중복 결제 방지 로직 추가
  - PaymentService.refund: 환불 처리 메서드 추가 (DB 상태값 CANCELLED로 변경)
  - PaymentRepository: 주문 ID 기반 결제 조회 메서드 추가
  - MenuRepository.findActiveById: 숨김/품절 메뉴 필터링 조건 추가
  - createOrder: 배송지 조회 방식 복원 (addressId 직접 지정)
  - 테스트 코드 PaymentService Mock 추가 및 주소 조회 방식 반영


## 📸 스크린샷(선택)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orders create payments during placement; refunds are triggered on cancel, reject, or delete.

* **Improvements**
  * Orders use the client-specified active delivery address at creation.
  * Duplicate payments for the same order are prevented.
  * Menu listings now exclude hidden or sold-out items.
  * Refunds validate payment state and return a clear error for invalid refund status.

* **Tests**
  * Order tests updated to mock payment flows, address lookup, and refund-not-found compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->