### PR TITLE
[refactor] 패키지 구조 개선 및 삭제 로직 보완

### DIFF
--- a/src/main/java/com/sparta/todayeats/area/controller/AreaController.java
+++ b/src/main/java/com/sparta/todayeats/area/controller/AreaController.java
@@ -1,10 +1,10 @@
-package com.sparta.todayeats.area.presentation.controller;
+package com.sparta.todayeats.area.controller;
 
-import com.sparta.todayeats.area.application.service.AreaService;
-import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
-import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
-import com.sparta.todayeats.area.presentation.dto.AreaResponse;
-import com.sparta.todayeats.area.presentation.dto.AreaUpdateRequest;
+import com.sparta.todayeats.area.service.AreaService;
+import com.sparta.todayeats.area.dto.request.AreaCreateRequest;
+import com.sparta.todayeats.area.dto.response.AreaCreateResponse;
+import com.sparta.todayeats.area.dto.response.AreaResponse;
+import com.sparta.todayeats.area.dto.request.AreaUpdateRequest;
 import com.sparta.todayeats.global.annotation.LoginUser;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.response.ApiResponse;
@@ -16,7 +16,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;

--- a/src/main/java/com/sparta/todayeats/area/dto/request/AreaCreateRequest.java
+++ b/src/main/java/com/sparta/todayeats/area/dto/request/AreaCreateRequest.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.area.presentation.dto;
+package com.sparta.todayeats.area.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/sparta/todayeats/area/dto/request/AreaUpdateRequest.java
+++ b/src/main/java/com/sparta/todayeats/area/dto/request/AreaUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.area.presentation.dto;
+package com.sparta.todayeats.area.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/sparta/todayeats/area/dto/response/AreaCreateResponse.java
+++ b/src/main/java/com/sparta/todayeats/area/dto/response/AreaCreateResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.area.presentation.dto;
+package com.sparta.todayeats.area.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/todayeats/area/dto/response/AreaResponse.java
+++ b/src/main/java/com/sparta/todayeats/area/dto/response/AreaResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.area.presentation.dto;
+package com.sparta.todayeats.area.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/todayeats/area/entity/Area.java
+++ b/src/main/java/com/sparta/todayeats/area/entity/Area.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.area.domain.entity;
+package com.sparta.todayeats.area.entity;
 
 import com.sparta.todayeats.global.infrastructure.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/sparta/todayeats/area/repository/AreaRepository.java
+++ b/src/main/java/com/sparta/todayeats/area/repository/AreaRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.todayeats.area.domain.repository;
+package com.sparta.todayeats.area.repository;
 
-import com.sparta.todayeats.area.domain.entity.Area;
+import com.sparta.todayeats.area.entity.Area;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/sparta/todayeats/area/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/service/AreaService.java
@@ -1,11 +1,11 @@
-package com.sparta.todayeats.area.application.service;
+package com.sparta.todayeats.area.service;
 
-import com.sparta.todayeats.area.domain.entity.Area;
-import com.sparta.todayeats.area.domain.repository.AreaRepository;
-import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
-import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
-import com.sparta.todayeats.area.presentation.dto.AreaResponse;
-import com.sparta.todayeats.area.presentation.dto.AreaUpdateRequest;
+import com.sparta.todayeats.area.entity.Area;
+import com.sparta.todayeats.area.repository.AreaRepository;
+import com.sparta.todayeats.area.dto.request.AreaCreateRequest;
+import com.sparta.todayeats.area.dto.response.AreaCreateResponse;
+import com.sparta.todayeats.area.dto.response.AreaResponse;
+import com.sparta.todayeats.area.dto.request.AreaUpdateRequest;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.exception.AreaErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;

--- a/src/main/java/com/sparta/todayeats/area/service/AreaService.java
+++ b/src/main/java/com/sparta/todayeats/area/service/AreaService.java
@@ -9,6 +9,7 @@ import com.sparta.todayeats.area.dto.request.AreaUpdateRequest;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.exception.AreaErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;
+import com.sparta.todayeats.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -26,6 +27,7 @@ import java.util.UUID;
 public class AreaService {
 
     private final AreaRepository areaRepository;
+    private final StoreRepository storeRepository;
 
     // 운영 지역 생성
     @Transactional
@@ -123,6 +125,12 @@ public class AreaService {
     @Transactional
     public void deleteArea(UUID areaId, UUID userId) {
         Area area = getAreaEntity(areaId);
+
+        // 연관 가게가 있으면 삭제 불가
+        if (storeRepository.existsByAreaIdAndDeletedAtIsNull(areaId)) {
+            throw new BaseException(AreaErrorCode.AREA_HAS_STORES);
+        }
+
         area.softDelete(userId);
     }
 
@@ -142,21 +150,6 @@ public class AreaService {
         }
     }
 
-    // Area 엔티티 → 목록 응답 DTO 변환
-    private AreaResponse toResponse(Area area) {
-        return AreaResponse.builder()
-                .areaId(area.getId())
-                .name(area.getName())
-                .city(area.getCity())
-                .district(area.getDistrict())
-                .isActive(area.getIsActive())
-                .createdAt(area.getCreatedAt())
-                .createdBy(area.getCreatedBy())
-                .updatedAt(area.getUpdatedAt())
-                .updatedBy(area.getUpdatedBy())
-                .build();
-    }
-
     // 운영지역 이름 정규화
     private String normalizeName(String name) {
         // null인 경우 예외 처리
@@ -172,6 +165,21 @@ public class AreaService {
     private Area getAreaEntity(UUID areaId) {
         return areaRepository.findById(areaId)
                 .orElseThrow(() -> new BaseException(AreaErrorCode.AREA_NOT_FOUND));
+    }
+
+    // Area 엔티티 → 목록 응답 DTO 변환
+    private AreaResponse toResponse(Area area) {
+        return AreaResponse.builder()
+                .areaId(area.getId())
+                .name(area.getName())
+                .city(area.getCity())
+                .district(area.getDistrict())
+                .isActive(area.getIsActive())
+                .createdAt(area.getCreatedAt())
+                .createdBy(area.getCreatedBy())
+                .updatedAt(area.getUpdatedAt())
+                .updatedBy(area.getUpdatedBy())
+                .build();
     }
 
 }

--- a/src/main/java/com/sparta/todayeats/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/todayeats/category/controller/CategoryController.java
@@ -1,7 +1,10 @@
-package com.sparta.todayeats.category.presentation.controller;
+package com.sparta.todayeats.category.controller;
 
-import com.sparta.todayeats.category.application.service.CategoryService;
-import com.sparta.todayeats.category.presentation.dto.*;
+import com.sparta.todayeats.category.dto.request.CategoryCreateRequest;
+import com.sparta.todayeats.category.dto.response.CategoryCreateResponse;
+import com.sparta.todayeats.category.dto.response.CategoryResponse;
+import com.sparta.todayeats.category.dto.request.CategoryUpdateRequest;
+import com.sparta.todayeats.category.service.CategoryService;
 import com.sparta.todayeats.global.annotation.LoginUser;
 import com.sparta.todayeats.global.response.ApiResponse;
 import com.sparta.todayeats.global.response.PageResponse;
@@ -13,7 +16,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;

--- a/src/main/java/com/sparta/todayeats/category/dto/request/CategoryCreateRequest.java
+++ b/src/main/java/com/sparta/todayeats/category/dto/request/CategoryCreateRequest.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.category.presentation.dto;
+package com.sparta.todayeats.category.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/sparta/todayeats/category/dto/request/CategoryUpdateRequest.java
+++ b/src/main/java/com/sparta/todayeats/category/dto/request/CategoryUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.category.presentation.dto;
+package com.sparta.todayeats.category.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/sparta/todayeats/category/dto/response/CategoryCreateResponse.java
+++ b/src/main/java/com/sparta/todayeats/category/dto/response/CategoryCreateResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.category.presentation.dto;
+package com.sparta.todayeats.category.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -6,17 +6,14 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-// 카테고리 정보 응답 DTO
+// 카테고리 생성 응답 DTO
 @Getter
 @Builder
-public class CategoryResponse {
+public class CategoryCreateResponse {
 
     private UUID categoryId;
     private String name;
 
     private LocalDateTime createdAt;
     private UUID createdBy;
-
-    private LocalDateTime updatedAt;
-    private UUID updatedBy;
 }

--- a/src/main/java/com/sparta/todayeats/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/sparta/todayeats/category/dto/response/CategoryResponse.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.category.presentation.dto;
+package com.sparta.todayeats.category.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -6,14 +6,17 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-// 카테고리 생성 응답 DTO
+// 카테고리 정보 응답 DTO
 @Getter
 @Builder
-public class CategoryCreateResponse {
+public class CategoryResponse {
 
     private UUID categoryId;
     private String name;
 
     private LocalDateTime createdAt;
     private UUID createdBy;
+
+    private LocalDateTime updatedAt;
+    private UUID updatedBy;
 }

--- a/src/main/java/com/sparta/todayeats/category/entity/Category.java
+++ b/src/main/java/com/sparta/todayeats/category/entity/Category.java
@@ -1,4 +1,4 @@
-package com.sparta.todayeats.category.domain.entity;
+package com.sparta.todayeats.category.entity;
 
 import com.sparta.todayeats.global.infrastructure.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/sparta/todayeats/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/todayeats/category/repository/CategoryRepository.java
@@ -1,6 +1,6 @@
-package com.sparta.todayeats.category.domain.repository;
+package com.sparta.todayeats.category.repository;
 
-import com.sparta.todayeats.category.domain.entity.Category;
+import com.sparta.todayeats.category.entity.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/sparta/todayeats/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/todayeats/category/service/CategoryService.java
@@ -9,6 +9,7 @@ import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.exception.CategoryErrorCode;
 import com.sparta.todayeats.global.response.PageResponse;
+import com.sparta.todayeats.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -25,6 +26,7 @@ import java.util.UUID;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final StoreRepository storeRepository;
 
     // 카테고리 생성
     @Transactional
@@ -116,22 +118,15 @@ public class CategoryService {
     public void deleteCategory(UUID categoryId, UUID deletedBy) {
         Category category = getCategoryEntity(categoryId);
 
+        // 연관 가게가 있으면 삭제 불가
+        if (storeRepository.existsByCategoryIdAndDeletedAtIsNull(categoryId)) {
+            throw new BaseException(CategoryErrorCode.CATEGORY_HAS_STORES);
+        }
+
         // 소프트 삭제 처리
         category.softDelete(deletedBy);
     }
 
-
-    // Category 엔티티 → 목록 응답 DTO 변환
-    private CategoryResponse toResponse(Category category) {
-        return CategoryResponse.builder()
-                .categoryId(category.getId())
-                .name(category.getName())
-                .createdAt(category.getCreatedAt())
-                .createdBy(category.getCreatedBy())
-                .updatedAt(category.getUpdatedAt())
-                .updatedBy(category.getUpdatedBy())
-                .build();
-    }
 
     // 카테고리 이름 중복 여부 확인 (삭제 안 된 것만 중복 체크)
     private void validateDuplicateCategory(String name) {
@@ -168,5 +163,17 @@ public class CategoryService {
         }
 
         return categoryRepository.findByNameContainingIgnoreCase(keyword, pageable);
+    }
+
+    // Category 엔티티 → 목록 응답 DTO 변환
+    private CategoryResponse toResponse(Category category) {
+        return CategoryResponse.builder()
+                .categoryId(category.getId())
+                .name(category.getName())
+                .createdAt(category.getCreatedAt())
+                .createdBy(category.getCreatedBy())
+                .updatedAt(category.getUpdatedAt())
+                .updatedBy(category.getUpdatedBy())
+                .build();
     }
 }

--- a/src/main/java/com/sparta/todayeats/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/todayeats/category/service/CategoryService.java
@@ -1,8 +1,11 @@
-package com.sparta.todayeats.category.application.service;
+package com.sparta.todayeats.category.service;
 
-import com.sparta.todayeats.category.domain.entity.Category;
-import com.sparta.todayeats.category.domain.repository.CategoryRepository;
-import com.sparta.todayeats.category.presentation.dto.*;
+import com.sparta.todayeats.category.dto.request.CategoryCreateRequest;
+import com.sparta.todayeats.category.dto.response.CategoryCreateResponse;
+import com.sparta.todayeats.category.dto.response.CategoryResponse;
+import com.sparta.todayeats.category.dto.request.CategoryUpdateRequest;
+import com.sparta.todayeats.category.entity.Category;
+import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.exception.CategoryErrorCode;
 import com.sparta.todayeats.global.response.PageResponse;

--- a/src/main/java/com/sparta/todayeats/global/exception/AreaErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/AreaErrorCode.java
@@ -10,7 +10,8 @@ public enum AreaErrorCode implements ErrorCode {
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "AREA-001", "지역을 찾을 수 없습니다."),
     AREA_ALREADY_EXISTS(HttpStatus.CONFLICT, "AREA-002", "이미 존재하는 지역입니다."),
     INVALID_AREA_NAME(HttpStatus.BAD_REQUEST, "AREA-003", "유효하지 않은 지역 이름입니다."),
-    AREA_INACTIVE(HttpStatus.BAD_REQUEST, "AREA-004", "비활성화된 지역입니다.");
+    AREA_INACTIVE(HttpStatus.BAD_REQUEST, "AREA-004", "비활성화된 지역입니다."),
+    AREA_HAS_STORES(HttpStatus.BAD_REQUEST, "AREA-005", "해당 운영지역에 등록된 가게가 있어 삭제할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/global/exception/CategoryErrorCode.java
+++ b/src/main/java/com/sparta/todayeats/global/exception/CategoryErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CategoryErrorCode implements ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CAT-001", "카테고리를 찾을 수 없습니다."),
     CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "CAT-002", "이미 존재하는 카테고리입니다."),
-    INVALID_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "CAT-003", "유효하지 않은 카테고리 이름입니다.");
+    INVALID_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "CAT-003", "유효하지 않은 카테고리 이름입니다."),
+    CATEGORY_HAS_STORES(HttpStatus.BAD_REQUEST, "CAT-004", "해당 카테고리에 등록된 가게가 있어 삭제할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
+++ b/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
@@ -1,7 +1,7 @@
 package com.sparta.todayeats.global.init;
 
-import com.sparta.todayeats.area.domain.entity.Area;
-import com.sparta.todayeats.area.domain.repository.AreaRepository;
+import com.sparta.todayeats.area.entity.Area;
+import com.sparta.todayeats.area.repository.AreaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;

--- a/src/main/java/com/sparta/todayeats/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/todayeats/menu/entity/Menu.java
@@ -4,7 +4,7 @@ import com.sparta.todayeats.global.infrastructure.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import com.sparta.todayeats.category.domain.entity.Category;
+import com.sparta.todayeats.category.entity.Category;
 import com.sparta.todayeats.store.entity.Store;
 
 import java.util.UUID;

--- a/src/main/java/com/sparta/todayeats/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/todayeats/menu/service/MenuService.java
@@ -1,7 +1,7 @@
 package com.sparta.todayeats.menu.service;
 
-import com.sparta.todayeats.category.domain.entity.Category;
-import com.sparta.todayeats.category.domain.repository.CategoryRepository;
+import com.sparta.todayeats.category.entity.Category;
+import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.menu.entity.Menu;
 import com.sparta.todayeats.menu.repository.MenuRepository;
 import com.sparta.todayeats.menu.dto.request.MenuCreateRequest;

--- a/src/main/java/com/sparta/todayeats/store/entity/Store.java
+++ b/src/main/java/com/sparta/todayeats/store/entity/Store.java
@@ -1,6 +1,6 @@
 package com.sparta.todayeats.store.entity;
 
-import com.sparta.todayeats.area.domain.entity.Area;
+import com.sparta.todayeats.area.entity.Area;
 import com.sparta.todayeats.category.entity.Category;
 import com.sparta.todayeats.global.infrastructure.entity.BaseEntity;
 import com.sparta.todayeats.user.entity.User;

--- a/src/main/java/com/sparta/todayeats/store/entity/Store.java
+++ b/src/main/java/com/sparta/todayeats/store/entity/Store.java
@@ -1,7 +1,7 @@
 package com.sparta.todayeats.store.entity;
 
 import com.sparta.todayeats.area.domain.entity.Area;
-import com.sparta.todayeats.category.domain.entity.Category;
+import com.sparta.todayeats.category.entity.Category;
 import com.sparta.todayeats.global.infrastructure.entity.BaseEntity;
 import com.sparta.todayeats.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
@@ -16,4 +16,8 @@ public interface StoreRepository extends JpaRepository<Store, UUID>, StoreReposi
     // store 조회 시 owner도 한번에 가져오기
     @Query("SELECT s FROM Store s JOIN FETCH s.owner WHERE s.id = :storeId")
     Optional<Store> findByIdWithOwner(@Param("storeId") UUID storeId);
+
+    // 카테고리에 속한 삭제되지 않은 가게 존재 여부 확인
+    boolean existsByCategoryIdAndDeletedAtIsNull(UUID categoryId);
+    
 }

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
@@ -19,5 +19,7 @@ public interface StoreRepository extends JpaRepository<Store, UUID>, StoreReposi
 
     // 카테고리에 속한 삭제되지 않은 가게 존재 여부 확인
     boolean existsByCategoryIdAndDeletedAtIsNull(UUID categoryId);
-    
+
+    // 운영지역에 속한 삭제되지 않은 가게 존재 여부 확인
+    boolean existsByAreaIdAndDeletedAtIsNull(UUID areaId);
 }

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -2,8 +2,8 @@ package com.sparta.todayeats.store.service;
 
 import com.sparta.todayeats.area.domain.entity.Area;
 import com.sparta.todayeats.area.domain.repository.AreaRepository;
-import com.sparta.todayeats.category.domain.entity.Category;
-import com.sparta.todayeats.category.domain.repository.CategoryRepository;
+import com.sparta.todayeats.category.entity.Category;
+import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.exception.*;
 import com.sparta.todayeats.store.dto.request.StoreCreateRequest;

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -1,7 +1,7 @@
 package com.sparta.todayeats.store.service;
 
-import com.sparta.todayeats.area.domain.entity.Area;
-import com.sparta.todayeats.area.domain.repository.AreaRepository;
+import com.sparta.todayeats.area.entity.Area;
+import com.sparta.todayeats.area.repository.AreaRepository;
 import com.sparta.todayeats.category.entity.Category;
 import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.global.response.PageResponse;

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -18,6 +18,7 @@ import com.sparta.todayeats.user.entity.User;
 import com.sparta.todayeats.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
@@ -64,8 +65,13 @@ public class StoreService {
                 .phone(normalizePhone(request.getPhone()))
                 .build();
 
-        // DB 저장
-        Store saved = storeRepository.save(store);
+        // DB 저장 (동시성 문제 해결)
+        Store saved;
+        try {
+            saved = storeRepository.save(store);
+        } catch (DataIntegrityViolationException e) {
+            throw new BaseException(StoreErrorCode.STORE_ALREADY_EXISTS);
+        }
 
         return toCreateResponse(saved);
     }

--- a/src/test/java/com/sparta/todayeats/area/service/AreaServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/area/service/AreaServiceTest.java
@@ -9,6 +9,7 @@ import com.sparta.todayeats.area.dto.request.AreaUpdateRequest;
 import com.sparta.todayeats.area.service.AreaService;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.exception.BaseException;
+import com.sparta.todayeats.store.repository.StoreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,9 @@ class AreaServiceTest {
 
     @Mock
     private AreaRepository areaRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
 
 
     // 운영 지역 생성
@@ -395,6 +399,8 @@ class AreaServiceTest {
 
             given(areaRepository.findById(id))
                     .willReturn(Optional.of(area));
+            // 연관 가게 없음
+            given(storeRepository.existsByAreaIdAndDeletedAtIsNull(id)).willReturn(false);
 
             // when
             areaService.deleteArea(id,userId);

--- a/src/test/java/com/sparta/todayeats/area/service/AreaServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/area/service/AreaServiceTest.java
@@ -1,11 +1,12 @@
-package com.sparta.todayeats.area.application.service;
+package com.sparta.todayeats.area.service;
 
-import com.sparta.todayeats.area.domain.entity.Area;
-import com.sparta.todayeats.area.domain.repository.AreaRepository;
-import com.sparta.todayeats.area.presentation.dto.AreaCreateRequest;
-import com.sparta.todayeats.area.presentation.dto.AreaCreateResponse;
-import com.sparta.todayeats.area.presentation.dto.AreaResponse;
-import com.sparta.todayeats.area.presentation.dto.AreaUpdateRequest;
+import com.sparta.todayeats.area.entity.Area;
+import com.sparta.todayeats.area.repository.AreaRepository;
+import com.sparta.todayeats.area.dto.request.AreaCreateRequest;
+import com.sparta.todayeats.area.dto.response.AreaCreateResponse;
+import com.sparta.todayeats.area.dto.response.AreaResponse;
+import com.sparta.todayeats.area.dto.request.AreaUpdateRequest;
+import com.sparta.todayeats.area.service.AreaService;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.exception.BaseException;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/sparta/todayeats/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/category/service/CategoryServiceTest.java
@@ -1,8 +1,13 @@
-package com.sparta.todayeats.category.application.service;
+package com.sparta.todayeats.category.service;
 
-import com.sparta.todayeats.category.domain.entity.Category;
-import com.sparta.todayeats.category.domain.repository.CategoryRepository;
+import com.sparta.todayeats.category.dto.request.CategoryCreateRequest;
+import com.sparta.todayeats.category.dto.response.CategoryCreateResponse;
+import com.sparta.todayeats.category.dto.response.CategoryResponse;
+import com.sparta.todayeats.category.dto.request.CategoryUpdateRequest;
+import com.sparta.todayeats.category.entity.Category;
+import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.category.presentation.dto.*;
+import com.sparta.todayeats.category.service.CategoryService;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.response.PageResponse;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/sparta/todayeats/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/category/service/CategoryServiceTest.java
@@ -6,10 +6,9 @@ import com.sparta.todayeats.category.dto.response.CategoryResponse;
 import com.sparta.todayeats.category.dto.request.CategoryUpdateRequest;
 import com.sparta.todayeats.category.entity.Category;
 import com.sparta.todayeats.category.repository.CategoryRepository;
-import com.sparta.todayeats.category.presentation.dto.*;
-import com.sparta.todayeats.category.service.CategoryService;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.response.PageResponse;
+import com.sparta.todayeats.store.repository.StoreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +38,9 @@ class CategoryServiceTest {
 
     @Mock
     private CategoryRepository categoryRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
 
     // 카테고리 생성
     @Nested
@@ -292,6 +294,9 @@ class CategoryServiceTest {
 
             given(categoryRepository.findById(categoryId))
                     .willReturn(Optional.of(category));
+
+            // 연관 가게 없음
+            given(storeRepository.existsByCategoryIdAndDeletedAtIsNull(categoryId)).willReturn(false);
 
             // when
             UUID userId = UUID.randomUUID();

--- a/src/test/java/com/sparta/todayeats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/menu/service/MenuServiceTest.java
@@ -1,7 +1,7 @@
 package com.sparta.todayeats.menu.service;
 
-import com.sparta.todayeats.category.domain.entity.Category;
-import com.sparta.todayeats.category.domain.repository.CategoryRepository;
+import com.sparta.todayeats.category.entity.Category;
+import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.menu.entity.Menu;
 import com.sparta.todayeats.menu.repository.MenuRepository;
 import com.sparta.todayeats.menu.dto.request.MenuCreateRequest;

--- a/src/test/java/com/sparta/todayeats/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/store/service/StoreServiceTest.java
@@ -1,7 +1,7 @@
 package com.sparta.todayeats.store.service;
 
-import com.sparta.todayeats.area.domain.entity.Area;
-import com.sparta.todayeats.area.domain.repository.AreaRepository;
+import com.sparta.todayeats.area.entity.Area;
+import com.sparta.todayeats.area.repository.AreaRepository;
 import com.sparta.todayeats.category.entity.Category;
 import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.global.exception.BaseException;

--- a/src/test/java/com/sparta/todayeats/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/store/service/StoreServiceTest.java
@@ -2,8 +2,8 @@ package com.sparta.todayeats.store.service;
 
 import com.sparta.todayeats.area.domain.entity.Area;
 import com.sparta.todayeats.area.domain.repository.AreaRepository;
-import com.sparta.todayeats.category.domain.entity.Category;
-import com.sparta.todayeats.category.domain.repository.CategoryRepository;
+import com.sparta.todayeats.category.entity.Category;
+import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.store.dto.request.StoreCreateRequest;
@@ -29,7 +29,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.Collection;


### PR DESCRIPTION
## 📌 관련 이슈
#50 


## ✨ 요약
- 카테고리, 운영지역 패기지 구조 변경 
- 카테고리, 운영지역 삭제 시 연관 관계 존재하면 삭제 불가 
- 테스트 코드 보완 


## 상세 내용
- 도메인 구조에 맞게 패키지 구조 수정 
- 카테고리 삭제 시 해당 카테고리에 속한 가게가 존재하면 삭제 불가 처리
- 운영지역 삭제 시 해당 지역에 속한 가게가 존재하면 삭제 불가 처리


## 📸 스크린샷(선택)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

Closes #50 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Areas and categories can no longer be deleted if they have stores associated, preventing accidental data loss.
  * Creating a store now yields a clear "already exists" error for duplicate stores, improving feedback on failed creations.
  * Improved robustness around store-related operations to reduce unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->