### PR TITLE
chore: SCP 타겟 수정, 빌드시 *-plain.jar파일 비활성화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: "build/libs/*.jar"
-          target: "/home/ubuntu/Sparta-TodayEats/build/libs/"
+          target: "/home/ubuntu/Sparta-TodayEats"
           strip_components: 2
 
       - name: Deploy to EC2
@@ -87,5 +87,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd /home/ubuntu/Sparta-TodayEats
-            docker-compose down
-            docker-compose up -d --build
+            mv TodayEats-*.jar app.jar
+            docker compose down
+            docker compose build --no-cache
+            docker compose up -d

--- a/build.gradle
+++ b/build.gradle
@@ -65,3 +65,7 @@ tasks.named('test') {
     finalizedBy jacocoTestReport
 
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
## 📌 관련 이슈


## ✨ 요약
- 배포시 경로 오류로 jar 파일을 찾지 못해 backend 도커 컨테이너가 재시작을 무한히 시도하는 현상 수정

## 상세 내용


## 📸 스크린샷(선택)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!— 참고할 사항이 있다면 적어주세요 —>

