### PR TITLE
[feat] 사용자 삭제 시 관련 도메인 연쇄 삭제 로직 구현

### DIFF
--- a/src/main/java/com/sparta/todayeats/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/todayeats/address/repository/AddressRepository.java
@@ -4,6 +4,7 @@ import com.sparta.todayeats.address.entity.Address;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +26,11 @@ public interface AddressRepository extends JpaRepository<Address, UUID> {
 
     @Query("SELECT a FROM Address a WHERE a.id = :addressId AND a.deletedAt IS NULL")
     Optional<Address> findActiveById(@Param("addressId") UUID addressId);
+
+    @Modifying
+    @Query("UPDATE Address a " +
+            "SET a.deletedAt = NOW(), a.deletedBy = :currentUserId " +
+            "WHERE a.user.userId = :targetUserId AND a.deletedAt IS NULL")
+    void softDeleteByUserId(@Param("targetUserId") UUID targetUserId,
+                            @Param("currentUserId") UUID currentUserId);
 }

--- a/src/main/java/com/sparta/todayeats/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/todayeats/address/repository/AddressRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,9 +29,12 @@ public interface AddressRepository extends JpaRepository<Address, UUID> {
     Optional<Address> findActiveById(@Param("addressId") UUID addressId);
 
     @Modifying
-    @Query("UPDATE Address a " +
-            "SET a.deletedAt = NOW(), a.deletedBy = :currentUserId " +
-            "WHERE a.user.userId = :targetUserId AND a.deletedAt IS NULL")
+    @Query("""
+        UPDATE Address a
+        SET a.deletedAt = :now, a.deletedBy = :currentUserId
+        WHERE a.user.userId = :targetUserId AND a.deletedAt IS NULL
+    """)
     void softDeleteByUserId(@Param("targetUserId") UUID targetUserId,
-                            @Param("currentUserId") UUID currentUserId);
+                            @Param("currentUserId") UUID currentUserId,
+                            @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sparta/todayeats/address/service/AddressService.java
+++ b/src/main/java/com/sparta/todayeats/address/service/AddressService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -141,6 +142,6 @@ public class AddressService {
     // 배송지 연쇄 삭제
     @Transactional
     public void deleteAllAddressesByUserId(UUID targetUserId, UUID currentUserId) {
-        addressRepository.softDeleteByUserId(targetUserId, currentUserId);
+        addressRepository.softDeleteByUserId(targetUserId, currentUserId, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/sparta/todayeats/address/service/AddressService.java
+++ b/src/main/java/com/sparta/todayeats/address/service/AddressService.java
@@ -137,4 +137,10 @@ public class AddressService {
         // 3. 소프트 딜리트
         address.softDelete(userId);
     }
+
+    // 배송지 연쇄 삭제
+    @Transactional
+    public void deleteAllAddressesByUserId(UUID targetUserId, UUID currentUserId) {
+        addressRepository.softDeleteByUserId(targetUserId, currentUserId);
+    }
 }

--- a/src/main/java/com/sparta/todayeats/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/todayeats/category/repository/CategoryRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
@@ -14,4 +15,6 @@ public interface CategoryRepository extends JpaRepository<Category, UUID> {
     // 카테고리 이름 기준 부분 일치(대소문자 무시) 검색 + 페이징 조회
     Page<Category> findByNameContainingIgnoreCase(String name, Pageable pageable);
 
+    // 테스트 데이터 생성용
+    Optional<Category> findByName(String name);
 }

--- a/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
+++ b/src/main/java/com/sparta/todayeats/global/init/DataInitializer.java
@@ -1,29 +1,185 @@
 package com.sparta.todayeats.global.init;
 
+import com.sparta.todayeats.address.entity.Address;
+import com.sparta.todayeats.address.repository.AddressRepository;
 import com.sparta.todayeats.area.entity.Area;
 import com.sparta.todayeats.area.repository.AreaRepository;
+import com.sparta.todayeats.category.entity.Category;
+import com.sparta.todayeats.category.repository.CategoryRepository;
+import com.sparta.todayeats.menu.entity.Menu;
+import com.sparta.todayeats.menu.repository.MenuRepository;
+import com.sparta.todayeats.order.entity.Order;
+import com.sparta.todayeats.order.entity.OrderStatus;
+import com.sparta.todayeats.order.entity.OrderType;
+import com.sparta.todayeats.order.repository.OrderRepository;
+import com.sparta.todayeats.review.entity.Review;
+import com.sparta.todayeats.review.repository.ReviewRepository;
+import com.sparta.todayeats.store.entity.Store;
+import com.sparta.todayeats.store.repository.StoreRepository;
+import com.sparta.todayeats.user.entity.User;
+import com.sparta.todayeats.user.entity.UserRoleEnum;
+import com.sparta.todayeats.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class DataInitializer implements ApplicationRunner {
-
     private final AreaRepository areaRepository;
+    private final UserRepository userRepository;
+    private final AddressRepository addressRepository;
+    private final CategoryRepository categoryRepository;
+    private final StoreRepository storeRepository;
+    private final OrderRepository orderRepository;
+    private final ReviewRepository reviewRepository;
+    private final MenuRepository menuRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
         if (areaRepository.existsByNameIgnoreCaseAndDeletedAtIsNull("광화문")) return; // 이미 있으면 스킵
 
-        areaRepository.save(Area.builder()
+        // 지역 생성
+        Area area = areaRepository.save(Area.builder()
                 .name("광화문")
                 .city("서울특별시")
                 .district("종로구")
                 .isActive(true)
                 .build());
+
+        // 카테고리 생성
+        Category category = createCategory("한식");
+
+        // MASTER 계정 생성
+        createUser("master@test.com", "Master123!", "마스터", UserRoleEnum.MASTER);
+
+        // OWNER 계정 생성 - 직접 삭제 시도
+        User owner1 = createUser("owner@test.com", "Owner123!", "삭제", UserRoleEnum.OWNER);
+        User owner2 = createUser("owner2@test.com", "Owner456!", "삭제안함", UserRoleEnum.OWNER);
+
+        // CUSTOMER 계정 생성 - 관리자 삭제 시도
+        User customer1 = createUser("customer@test.com", "User123!", "삭제", UserRoleEnum.CUSTOMER);
+        User customer2 = createUser("customer2@test.com", "User456!", "삭제안함", UserRoleEnum.CUSTOMER);
+
+        // 가게 생성
+        Store store1 = createStore(owner1, area, category, "삭제의 쌈밥집", "대한민국", "02-123-4567");
+        Store store2 = createStore(owner2, area, category, "삭제안함의 쌈밥집", "대한민국", "02-123-4567");
+
+        // 메뉴 생성
+        createMenu(store1, category, "제육 쌈밥 정식", 12000L, "매콤한 제육볶음과 신선한 쌈채소");
+
+        // 삭제할 사용자 배송지 등록
+        Address address = createAddress(customer1, "우리집", "대한민국", "1호", "12345");
+
+        // 주문 생성
+        Order order = createOrder(customer1, store1, address, OrderStatus.COMPLETED);
+        createOrder(customer2, store2, address, OrderStatus.PENDING);
+
+        // 리뷰 생성
+        createReview(customer1, store1, order, 4, "배달이 빨라서 좋았습니다.");
+    }
+
+    private User createUser(String email, String rawPassword, String nickname, UserRoleEnum role) {
+        return userRepository.findByEmail(email).orElseGet(() -> {
+            User user = User.builder()
+                    .email(email)
+                    .password(passwordEncoder.encode(rawPassword))
+                    .nickname(nickname)
+                    .role(role)
+                    .build();
+            return userRepository.save(user);
+        });
+    }
+
+    private Address createAddress(User user, String alias, String addr, String detail, String zip) {
+        Address address = Address.builder()
+                .user(user)
+                .alias(alias)
+                .address(addr)
+                .detail(detail)
+                .zipCode(zip)
+                .isDefault(false)
+                .build();
+        return addressRepository.save(address);
+    }
+
+    private Category createCategory(String name) {
+        return categoryRepository.findByName(name)
+                .orElseGet(() -> categoryRepository.save(Category.builder()
+                        .name(name)
+                        .build()));
+    }
+
+    private Store createStore(User owner, Area area, Category category, String name, String addr, String phone) {
+        if (storeRepository.existsByName(name)) {
+            return storeRepository.findByName(name).orElse(null);
+        }
+
+        Store store = Store.builder()
+                .owner(owner)
+                .area(area)
+                .category(category)
+                .name(name)
+                .address(addr)
+                .phone(phone) // 필요 시 normalizePhone 로직 적용
+                .build();
+        return storeRepository.save(store);
+    }
+
+    private Order createOrder(User user, Store store, Address address, OrderStatus targetStatus) {
+        Order order = Order.builder()
+                .customerId(user.getUserId())
+                .storeId(store.getId())
+                .addressId(address.getId())
+                .storeName(store.getName())
+                .deliveryAddress(address.getAddress())
+                .deliveryDetail(address.getDetail())
+                .orderType(OrderType.ONLINE)
+                .note("문 앞에 놓아주세요.")
+                .totalPrice(25000L)
+                .build();
+
+        // 주문 완료 상태로 변경
+        if (targetStatus == OrderStatus.COMPLETED) {
+            order.updateStatus(OrderStatus.ACCEPTED);
+            order.updateStatus(OrderStatus.COOKING);
+            order.updateStatus(OrderStatus.DELIVERING);
+            order.updateStatus(OrderStatus.DELIVERED);
+            order.updateStatus(OrderStatus.COMPLETED);
+        }
+
+        return orderRepository.save(order);
+    }
+
+    private void createReview(User user, Store store, Order order, Integer rating, String content) {
+        Review review = Review.builder()
+                .user(user)
+                .store(store)
+                .order(order)
+                .rating(rating)
+                .content(content)
+                .build();
+        reviewRepository.save(review);
+    }
+
+    private void createMenu(Store store, Category category, String name, Long price, String desc) {
+        if (menuRepository.existsByNameAndStore(name, store)) return;
+
+        Menu menu = Menu.builder()
+                .name(name)
+                .price(price)
+                .description(desc)
+                .imageUrl("https://example.com/menu-image.png")
+                .category(category)
+                .store(store)
+                .isHidden(false)
+                .soldOut(false)
+                .build();
+        menuRepository.save(menu);
     }
 }

--- a/src/main/java/com/sparta/todayeats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/todayeats/menu/repository/MenuRepository.java
@@ -1,9 +1,11 @@
 package com.sparta.todayeats.menu.repository;
 
 import com.sparta.todayeats.menu.entity.Menu;
+import com.sparta.todayeats.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -88,4 +90,14 @@ public interface MenuRepository extends JpaRepository<Menu, UUID> {
         AND m.soldOut = false
     """)
     Optional<Menu> findActiveById(@Param("menuId") UUID menuId);
+
+    @Modifying
+    @Query("UPDATE Menu m " +
+            "SET m.deletedAt = NOW(), m.deletedBy = :currentUserId " +
+            "WHERE m.store.id = :storeId AND m.deletedAt IS NULL")
+    void softDeleteByStoreId(@Param("storeId") UUID storeId,
+                             @Param("currentUserId") UUID currentUserId);
+
+    // 테스트 데이터 생성용
+    boolean existsByNameAndStore(String name, Store store);
 }

--- a/src/main/java/com/sparta/todayeats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/todayeats/menu/repository/MenuRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.Optional;
@@ -92,11 +93,14 @@ public interface MenuRepository extends JpaRepository<Menu, UUID> {
     Optional<Menu> findActiveById(@Param("menuId") UUID menuId);
 
     @Modifying
-    @Query("UPDATE Menu m " +
-            "SET m.deletedAt = NOW(), m.deletedBy = :currentUserId " +
-            "WHERE m.store.id = :storeId AND m.deletedAt IS NULL")
+    @Query("""
+        UPDATE Menu m
+        SET m.deletedAt = :now, m.deletedBy = :currentUserId
+        WHERE m.store.id = :storeId AND m.deletedAt IS NULL
+    """)
     void softDeleteByStoreId(@Param("storeId") UUID storeId,
-                             @Param("currentUserId") UUID currentUserId);
+                             @Param("currentUserId") UUID currentUserId,
+                             @Param("now") LocalDateTime now);
 
     // 테스트 데이터 생성용
     boolean existsByNameAndStore(String name, Store store);

--- a/src/main/java/com/sparta/todayeats/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/todayeats/menu/service/MenuService.java
@@ -161,4 +161,10 @@ public class MenuService {
             throw new IllegalArgumentException("해당 가게의 사장님만 접근할 수 있습니다.");
         }
     }
+
+    // 메뉴 연쇄 삭제
+    @Transactional
+    public void deleteAllMenusByStoreId(UUID storeId, UUID currentUserId) {
+        menuRepository.softDeleteByStoreId(storeId, currentUserId);
+    }
 }

--- a/src/main/java/com/sparta/todayeats/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/todayeats/menu/service/MenuService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -165,6 +166,6 @@ public class MenuService {
     // 메뉴 연쇄 삭제
     @Transactional
     public void deleteAllMenusByStoreId(UUID storeId, UUID currentUserId) {
-        menuRepository.softDeleteByStoreId(storeId, currentUserId);
+        menuRepository.softDeleteByStoreId(storeId, currentUserId, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/sparta/todayeats/order/entity/Order.java
+++ b/src/main/java/com/sparta/todayeats/order/entity/Order.java
@@ -151,4 +151,10 @@ public class Order extends BaseEntity {
     public void delete(UUID userId) {
         this.softDelete(userId);
     }
+
+    // 테스트 데이터 생성용
+    public void updateStatus(OrderStatus nextStatus) {
+        validateStatusTransition(nextStatus);
+        this.status = nextStatus;
+    }
 }

--- a/src/main/java/com/sparta/todayeats/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/todayeats/order/repository/OrderRepository.java
@@ -176,10 +176,11 @@ public interface OrderRepository extends JpaRepository<Order, UUID> {
      * 사용자 삭제 전 검증에 사용
      */
     @Query("SELECT COUNT(o) > 0 FROM Order o " +
-            "WHERE o.customerId = :customerId " +
+            "WHERE (o.customerId = :userId OR o.storeId IN " +
+            "      (SELECT s.id FROM Store s WHERE s.owner.userId = :userId AND s.deletedAt IS NULL)) " +
             "AND o.status NOT IN (com.sparta.todayeats.order.entity.OrderStatus.COMPLETED, " +
             "                     com.sparta.todayeats.order.entity.OrderStatus.CANCELED, " +
             "                     com.sparta.todayeats.order.entity.OrderStatus.REJECTED) " +
             "AND o.deletedAt IS NULL")
-    boolean existsActiveOrderByCustomerId(@Param("customerId") UUID customerId);
+    boolean existsActiveOrderByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/sparta/todayeats/order/service/OrderService.java
+++ b/src/main/java/com/sparta/todayeats/order/service/OrderService.java
@@ -352,7 +352,7 @@ public class OrderService {
      * UserService에서 사용자 삭제 전 호출
      */
     public boolean hasActiveOrders(UUID userId) {
-        return orderRepository.existsActiveOrderByCustomerId(userId);
+        return orderRepository.existsActiveOrderByUserId(userId);
     }
 
     /**

--- a/src/main/java/com/sparta/todayeats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/todayeats/review/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,9 +40,12 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     Optional<Review> getReviewById(@Param("id") UUID id);
 
     @Modifying
-    @Query("UPDATE Review r " +
-            "SET r.deletedAt = NOW(), r.deletedBy = :currentUserId " +
-            "WHERE r.user.userId = :targetUserId AND r.deletedAt IS NULL")
+    @Query("""
+        UPDATE Review r
+        SET r.deletedAt = :now, r.deletedBy = :currentUserId
+        WHERE r.user.userId = :targetUserId AND r.deletedAt IS NULL
+    """)
     void softDeleteByUserId(@Param("targetUserId") UUID targetUserId,
-                            @Param("currentUserId") UUID currentUserId);
+                            @Param("currentUserId") UUID currentUserId,
+                            @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sparta/todayeats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/todayeats/review/repository/ReviewRepository.java
@@ -4,6 +4,7 @@ import com.sparta.todayeats.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,4 +37,11 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
             "JOIN FETCH r.order " +
             "WHERE r.id = :id AND r.deletedAt IS NULL")
     Optional<Review> getReviewById(@Param("id") UUID id);
+
+    @Modifying
+    @Query("UPDATE Review r " +
+            "SET r.deletedAt = NOW(), r.deletedBy = :currentUserId " +
+            "WHERE r.user.userId = :targetUserId AND r.deletedAt IS NULL")
+    void softDeleteByUserId(@Param("targetUserId") UUID targetUserId,
+                            @Param("currentUserId") UUID currentUserId);
 }

--- a/src/main/java/com/sparta/todayeats/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/todayeats/review/service/ReviewService.java
@@ -163,4 +163,10 @@ public class ReviewService {
         // 2. 소프트 딜리트
         review.softDelete(userId);
     }
+
+    // 리뷰 연쇄 삭제
+    @Transactional
+    public void deleteAllReviewsByUserId(UUID targetUserId, UUID currentUserId) {
+        reviewRepository.softDeleteByUserId(targetUserId, currentUserId);
+    }
 }

--- a/src/main/java/com/sparta/todayeats/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/todayeats/review/service/ReviewService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 
@@ -167,6 +168,6 @@ public class ReviewService {
     // 리뷰 연쇄 삭제
     @Transactional
     public void deleteAllReviewsByUserId(UUID targetUserId, UUID currentUserId) {
-        reviewRepository.softDeleteByUserId(targetUserId, currentUserId);
+        reviewRepository.softDeleteByUserId(targetUserId, currentUserId, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/todayeats/store/repository/StoreRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,4 +23,10 @@ public interface StoreRepository extends JpaRepository<Store, UUID>, StoreReposi
 
     // 운영지역에 속한 삭제되지 않은 가게 존재 여부 확인
     boolean existsByAreaIdAndDeletedAtIsNull(UUID areaId);
+
+    List<Store> findAllByOwnerUserId(UUID userId);
+
+    // 테스트 데이터 생성용
+    boolean existsByName(String name);
+    Optional<Store> findByName(String name);
 }

--- a/src/main/java/com/sparta/todayeats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/todayeats/store/service/StoreService.java
@@ -6,6 +6,7 @@ import com.sparta.todayeats.category.entity.Category;
 import com.sparta.todayeats.category.repository.CategoryRepository;
 import com.sparta.todayeats.global.response.PageResponse;
 import com.sparta.todayeats.global.exception.*;
+import com.sparta.todayeats.menu.service.MenuService;
 import com.sparta.todayeats.store.dto.request.StoreCreateRequest;
 import com.sparta.todayeats.store.dto.request.StoreHiddenRequest;
 import com.sparta.todayeats.store.dto.request.StoreUpdateRequest;
@@ -35,6 +36,7 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class StoreService {
 
+    private final MenuService menuService;
     private final StoreRepository storeRepository;
     private final AreaRepository areaRepository;
     private final CategoryRepository categoryRepository;
@@ -324,5 +326,20 @@ public class StoreService {
                 .updatedAt(store.getUpdatedAt())
                 .updatedBy(store.getUpdatedBy())
                 .build();
+    }
+
+    // 가게 연쇄 삭제
+    @Transactional
+    public void deleteAllStoresByUserId(UUID targetUserId, UUID currentUserId) {
+        // 가게 목록
+        List<Store> ownerStores = storeRepository.findAllByOwnerUserId(targetUserId);
+
+        for (Store store : ownerStores) {
+            // 가게 메뉴 Soft Delete
+            menuService.deleteAllMenusByStoreId(store.getId(), currentUserId);
+
+            // 가게 Soft Delete
+            store.softDelete(currentUserId);
+        }
     }
 }

--- a/src/main/java/com/sparta/todayeats/user/service/UserService.java
+++ b/src/main/java/com/sparta/todayeats/user/service/UserService.java
@@ -1,11 +1,14 @@
 package com.sparta.todayeats.user.service;
 
+import com.sparta.todayeats.address.service.AddressService;
 import com.sparta.todayeats.auth.application.service.AuthService;
 import com.sparta.todayeats.global.exception.BaseException;
 import com.sparta.todayeats.global.exception.UserErrorCode;
 import com.sparta.todayeats.global.service.UserAuthorizationService;
 import com.sparta.todayeats.global.util.PageableUtils;
 import com.sparta.todayeats.order.service.OrderService;
+import com.sparta.todayeats.review.service.ReviewService;
+import com.sparta.todayeats.store.service.StoreService;
 import com.sparta.todayeats.user.entity.User;
 import com.sparta.todayeats.user.entity.UserRoleEnum;
 import com.sparta.todayeats.user.repository.UserRepository;
@@ -29,6 +32,9 @@ public class UserService {
     private final UserAuthorizationService userAuthorizationService;
     private final AuthService authService;
     private final OrderService orderService;
+    private final AddressService addressService;
+    private final StoreService storeService;
+    private final ReviewService reviewService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -144,7 +150,11 @@ public class UserService {
         }
 
         targetUser.softDelete(currentUserId);
-        // TODO: 관련 도메인에서 soft delete 처리 필요
+
+        // 관련 도메인 soft delete 처리
+        addressService.deleteAllAddressesByUserId(targetUserId, currentUserId);
+        storeService.deleteAllStoresByUserId(targetUserId, currentUserId);
+        reviewService.deleteAllReviewsByUserId(targetUserId, currentUserId);
 
         // Redis에 Refresh Token 삭제
         authService.deleteRefreshToken(targetUserId.toString());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+app:
+  url:
+    base: http://localhost:8080
+    password-reset-path: /api/v1/auth/reset-password
+
 spring:
   jpa:
     hibernate:
@@ -11,8 +16,24 @@ spring:
   data:
     redis:
       port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 gemini:
   api:
     key: ${GEMINI_API_KEY}
     url: ${GEMINI_API_URL}
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access-expiration: 1800000 # 30분 (30 * 60 * 1000)
+  refresh-expiration: 604800000 # 7일 (7 * 24 * 60 * 60 * 1000)

--- a/src/test/java/com/sparta/todayeats/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/todayeats/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.sparta.todayeats.user.service;
 
+import com.sparta.todayeats.address.service.AddressService;
 import com.sparta.todayeats.auth.application.service.AuthService;
 import com.sparta.todayeats.global.exception.AuthErrorCode;
 import com.sparta.todayeats.global.exception.BaseException;
@@ -7,6 +8,8 @@ import com.sparta.todayeats.global.exception.CommonErrorCode;
 import com.sparta.todayeats.global.exception.UserErrorCode;
 import com.sparta.todayeats.global.service.UserAuthorizationService;
 import com.sparta.todayeats.order.service.OrderService;
+import com.sparta.todayeats.review.service.ReviewService;
+import com.sparta.todayeats.store.service.StoreService;
 import com.sparta.todayeats.user.entity.User;
 import com.sparta.todayeats.user.entity.UserRoleEnum;
 import com.sparta.todayeats.user.repository.UserRepository;
@@ -51,6 +54,15 @@ class UserServiceTest {
 
     @Mock
     private OrderService orderService;
+
+    @Mock
+    private AddressService addressService;
+
+    @Mock
+    private StoreService storeService;
+
+    @Mock
+    private ReviewService reviewService;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -332,6 +344,9 @@ class UserServiceTest {
             // then
             assertThat(response).isNull();
             assertThat(user.getDeletedAt()).isNotNull();
+            verify(addressService).deleteAllAddressesByUserId(CURRENT_USER_ID, CURRENT_USER_ID);
+            verify(storeService).deleteAllStoresByUserId(CURRENT_USER_ID, CURRENT_USER_ID);
+            verify(reviewService).deleteAllReviewsByUserId(CURRENT_USER_ID, CURRENT_USER_ID);
             verify(authService).deleteRefreshToken(CURRENT_USER_ID.toString());
         }
 
@@ -353,6 +368,9 @@ class UserServiceTest {
             assertThat(response.getDeletedAt()).isNotNull();
             assertThat(targetUser.getDeletedAt()).isNotNull();
             assertThat(currentUser.getDeletedAt()).isNull();
+            verify(addressService).deleteAllAddressesByUserId(TARGET_USER_ID, CURRENT_USER_ID);
+            verify(storeService).deleteAllStoresByUserId(TARGET_USER_ID, CURRENT_USER_ID);
+            verify(reviewService).deleteAllReviewsByUserId(TARGET_USER_ID, CURRENT_USER_ID);
             verify(authService).deleteRefreshToken(TARGET_USER_ID.toString());
         }
 


### PR DESCRIPTION
## 📌 관련 이슈
#60 


## ✨ 요약
사용자 삭제 시 데이터 정합성을 유지하기 위해 관련 도메인 연쇄 삭제
- 배송지 연쇄 삭제 로직 추가
- 리뷰 연쇄 삭제 로직 추가
- 가게 연쇄 삭제 로직 추가
- 메뉴 연쇄 삭제 로직 추가

## 상세 내용
### 관련 도메인 연쇄 삭제 로직
- **사용자 ID 기반 처리**: Address / Review / Store 도메인
- **가게 ID 기반 처리**: Menu 도메인
- **벌크 연산 활용**: Address / Review / Menu 도메인

### 주문 상태 확인 로직
- 가게 주인의 주문 상태까지 확인하도록 범위 확장


## 📸 스크린샷(선택)
- 없음


## 📚 레퍼런스 혹은 궁금한 사항들
- 없음

Closes #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk soft-delete operations for addresses, reviews, menus, stores, and menus-by-store
  * Cascading user deletion that cleans up related addresses, stores, and reviews
  * Expanded demo data seeding (users, stores, menus, orders, reviews)
  * Menu name uniqueness check and order status update helper
  * Added email (SMTP) and JWT configuration properties

* **Bug Fixes**
  * Active order detection now includes orders tied to store owners

* **Tests**
  * Updated user service tests to assert cascading deletions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->